### PR TITLE
Add bootstrapper label to boostrap node.

### DIFF
--- a/modules/k8s-bootstrap/main.tf
+++ b/modules/k8s-bootstrap/main.tf
@@ -5,7 +5,7 @@ module "common" {
 module "k8s-node" {
   source                = "../k8s-node-ignition"
   dns_service_ip        = "${var.dns_service_ip}"
-  node_labels           = "node-role.kubernetes.io/master"
+  node_labels           = "node-role.kubernetes.io/master,node-role.kubernetes.io/bootstrapper"
   node_taints           = "node-role.kubernetes.io/master=:NoSchedule"
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   k8s_tag               = "${var.k8s_tag}"


### PR DESCRIPTION
This will allow the bootstrapper node to be easily identified by a
calling script that we may want to write to automate the up-down nature
of the bootstrapper.