### PR TITLE
Control access to the s3 user data via instance profiles.

### DIFF
--- a/modules/etcd-cluster/iam.tf
+++ b/modules/etcd-cluster/iam.tf
@@ -19,6 +19,11 @@ resource "aws_iam_role_policy_attachment" "etcd-ssm-policy-attachment" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
+resource "aws_iam_role_policy_attachment" "etcd-s3-user-data-policy-attachment" {
+  role       = "${aws_iam_role.etcd_role.id}"
+  policy_arn = "${var.s3_user_data_policy_arn}"
+}
+
 resource "aws_iam_instance_profile" "etcd_profile" {
   name = "${var.cluster_name}-etcd-instance-role"
   role = "${aws_iam_role.etcd_role.name}"

--- a/modules/etcd-cluster/ignition.tf
+++ b/modules/etcd-cluster/ignition.tf
@@ -82,7 +82,7 @@ data "ignition_config" "etcd-actual" {
   count = "${var.node_count}"
 
   replace = {
-    source       = "https://s3.${var.user_data_bucket_region}.amazonaws.com/${var.user_data_bucket_name}${element(data.template_file.user_data_object_key.*.rendered, count.index)}"
+    source       = "s3://${var.user_data_bucket_name}${element(data.template_file.user_data_object_key.*.rendered, count.index)}"
     verification = "sha512-${sha512(element(data.ignition_config.etcd.*.rendered, count.index))}"
   }
 }

--- a/modules/etcd-cluster/variables.tf
+++ b/modules/etcd-cluster/variables.tf
@@ -26,6 +26,10 @@ variable "user_data_bucket_region" {
   type = "string"
 }
 
+variable "s3_user_data_policy_arn" {
+  type = "string"
+}
+
 variable "node_count" {
   type    = "string"
   default = "3"

--- a/modules/gsp-cluster/iam.tf
+++ b/modules/gsp-cluster/iam.tf
@@ -5,20 +5,8 @@ data "aws_iam_policy_document" "user_data_policy_document" {
     ]
 
     resources = [
-      "${data.aws_s3_bucket.user_data.arn}/*",
+      "${data.aws_s3_bucket.user_data.arn}/user_data/${var.cluster_name}-*",
     ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:sourceVpc"
-
-      values = ["${aws_vpc.network.id}"]
-    }
   }
 }
 
@@ -26,7 +14,7 @@ data "aws_s3_bucket" "user_data" {
   bucket = "${var.user_data_bucket_name}"
 }
 
-resource "aws_s3_bucket_policy" "user_data_bucket_policy" {
-  bucket = "${data.aws_s3_bucket.user_data.id}"
+resource "aws_iam_policy" "s3-user-data-policy" {
+  name   = "${var.cluster_name}-s3-user-data-policy"
   policy = "${data.aws_iam_policy_document.user_data_policy_document.json}"
 }

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -10,6 +10,7 @@ module "etcd-cluster" {
   user_data_bucket_name   = "${var.user_data_bucket_name}"
   user_data_bucket_region = "${var.user_data_bucket_region}"
   instance_type           = "${var.etcd_instance_type}"
+  s3_user_data_policy_arn = "${aws_iam_policy.s3-user-data-policy.arn}"
 }
 
 module "bootkube-assets" {
@@ -48,4 +49,5 @@ module "k8s-cluster" {
   worker_count             = "${var.worker_count}"
   controller_instance_type = "${var.controller_instance_type}"
   worker_instance_type     = "${var.worker_instance_type}"
+  s3_user_data_policy_arn  = "${aws_iam_policy.s3-user-data-policy.arn}"
 }

--- a/modules/gsp-cluster/network.tf
+++ b/modules/gsp-cluster/network.tf
@@ -74,13 +74,6 @@ resource "aws_route_table_association" "cluster-public" {
   subnet_id      = "${element(aws_subnet.cluster-public.*.id, count.index)}"
 }
 
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = "${aws_vpc.network.id}"
-  service_name      = "com.amazonaws.eu-west-2.s3"
-  vpc_endpoint_type = "Gateway"
-  route_table_ids   = ["${aws_route_table.cluster-private.*.id}"]
-}
-
 resource "aws_eip" "public" {
   count = "${length(data.aws_availability_zones.all.names)}"
 

--- a/modules/k8s-bootstrap/ignition.tf
+++ b/modules/k8s-bootstrap/ignition.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_object" "bootstrap-user-data" {
 
 data "ignition_config" "bootstrap-actual" {
   replace = {
-    source       = "https://s3.${var.user_data_bucket_region}.amazonaws.com/${var.user_data_bucket_name}${data.template_file.bootstrap-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${data.template_file.bootstrap-user-data-object-key.rendered}"
     verification = "sha512-${sha512(data.ignition_config.bootstrap.rendered)}"
   }
 }

--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -102,6 +102,11 @@ resource "aws_iam_role_policy_attachment" "controller-ssm-policy-attachment" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
+resource "aws_iam_role_policy_attachment" "controller-s3-user-data-policy-attachment" {
+  role       = "${aws_iam_role.controller_role.id}"
+  policy_arn = "${var.s3_user_data_policy_arn}"
+}
+
 resource "aws_iam_instance_profile" "controller_profile" {
   name = "${var.cluster_name}-controller-instance-role"
   role = "${aws_iam_role.controller_role.name}"
@@ -154,6 +159,11 @@ resource "aws_iam_role_policy_attachment" "worker-policy-attachment" {
 resource "aws_iam_role_policy_attachment" "worker-ssm-policy-attachment" {
   role       = "${aws_iam_role.worker_role.id}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_iam_role_policy_attachment" "worker-s3-user-data-policy-attachment" {
+  role       = "${aws_iam_role.worker_role.id}"
+  policy_arn = "${var.s3_user_data_policy_arn}"
 }
 
 resource "aws_iam_instance_profile" "worker_profile" {

--- a/modules/k8s-cluster/ignition.tf
+++ b/modules/k8s-cluster/ignition.tf
@@ -62,7 +62,7 @@ resource "aws_s3_bucket_object" "controller-user-data" {
 
 data "ignition_config" "controller-actual" {
   replace = {
-    source       = "https://s3.${var.user_data_bucket_region}.amazonaws.com/${var.user_data_bucket_name}${data.template_file.controller-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${data.template_file.controller-user-data-object-key.rendered}"
     verification = "sha512-${sha512(data.ignition_config.controller.rendered)}"
   }
 }
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_object" "worker-user-data" {
 
 data "ignition_config" "worker-actual" {
   replace = {
-    source       = "https://s3.${var.user_data_bucket_region}.amazonaws.com/${var.user_data_bucket_name}${data.template_file.worker-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${data.template_file.worker-user-data-object-key.rendered}"
     verification = "sha512-${sha512(data.ignition_config.worker.rendered)}"
   }
 }

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -42,6 +42,10 @@ variable "k8s_tag" {
   type = "string"
 }
 
+variable "s3_user_data_policy_arn" {
+  type = "string"
+}
+
 variable "service_cidr" {
   type    = "string"
   default = "10.3.0.0/24"


### PR DESCRIPTION
Previously this was done using a vpc endpoint with an s3 bucket policy
that allowed access to anything coming from that vpc. Of course, every
vpc we spun up broke the bucket policy for the others. So, we have
reversed the policy so it is controlled from the things doing the accessing
(ec2 instance profiles) rather than being controlled from the thing being
accessed (s3 bucket objects).