### PR TITLE
Mark bootstrapper with different taints.

### DIFF
--- a/modules/k8s-bootstrap/main.tf
+++ b/modules/k8s-bootstrap/main.tf
@@ -5,8 +5,8 @@ module "common" {
 module "k8s-node" {
   source                = "../k8s-node-ignition"
   dns_service_ip        = "${var.dns_service_ip}"
-  node_labels           = "node-role.kubernetes.io/master,node-role.kubernetes.io/bootstrapper"
-  node_taints           = "node-role.kubernetes.io/master=:NoSchedule"
+  node_labels           = "node-role.kubernetes.io/bootstrapper"
+  node_taints           = "node-role.kubernetes.io/bootstrapper=:NoSchedule"
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   k8s_tag               = "${var.k8s_tag}"
   kubelet_kubeconfig    = "${var.kubelet_kubeconfig}"


### PR DESCRIPTION
To prevent the actual control plane from being scheduled onto the
bootstrapper.