### PR TITLE
Ensure the s3 bucket object has been uploaded before instance creation.

### DIFF
--- a/modules/etcd-cluster/ignition.tf
+++ b/modules/etcd-cluster/ignition.tf
@@ -82,7 +82,7 @@ data "ignition_config" "etcd-actual" {
   count = "${var.node_count}"
 
   replace = {
-    source       = "s3://${var.user_data_bucket_name}${element(data.template_file.user_data_object_key.*.rendered, count.index)}"
+    source       = "s3://${var.user_data_bucket_name}${element(aws_s3_bucket_object.etcd-user-data.*.id, count.index)}"
     verification = "sha512-${sha512(element(data.ignition_config.etcd.*.rendered, count.index))}"
   }
 }

--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -1,5 +1,5 @@
 output "bootstrap-base-userdata-source" {
-  value = "s3://${var.user_data_bucket_name}${data.template_file.user-data-object-key.rendered}"
+  value = "s3://${var.user_data_bucket_name}${aws_s3_bucket_object.bootstrap-user-data.id}"
 }
 
 output "bootstrap-base-userdata-verification" {

--- a/modules/k8s-bootstrap/ignition.tf
+++ b/modules/k8s-bootstrap/ignition.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_object" "bootstrap-user-data" {
 
 data "ignition_config" "bootstrap-actual" {
   replace = {
-    source       = "s3://${var.user_data_bucket_name}${data.template_file.bootstrap-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${aws_s3_bucket_object.bootstrap-user-data.id}"
     verification = "sha512-${sha512(data.ignition_config.bootstrap.rendered)}"
   }
 }

--- a/modules/k8s-cluster/ignition.tf
+++ b/modules/k8s-cluster/ignition.tf
@@ -62,7 +62,7 @@ resource "aws_s3_bucket_object" "controller-user-data" {
 
 data "ignition_config" "controller-actual" {
   replace = {
-    source       = "s3://${var.user_data_bucket_name}${data.template_file.controller-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${aws_s3_bucket_object.controller-user-data.id}"
     verification = "sha512-${sha512(data.ignition_config.controller.rendered)}"
   }
 }
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_object" "worker-user-data" {
 
 data "ignition_config" "worker-actual" {
   replace = {
-    source       = "s3://${var.user_data_bucket_name}${data.template_file.worker-user-data-object-key.rendered}"
+    source       = "s3://${var.user_data_bucket_name}${aws_s3_bucket_object.worker-user-data.id}"
     verification = "sha512-${sha512(data.ignition_config.worker.rendered)}"
   }
 }


### PR DESCRIPTION
A race condition existed whereby an instance could start and try and load
the user data from the s3 bucket but the terraform hadn't uploaded the
object yet. This should ensure that race condition doesn't happen.