### PR TITLE
move canary module from gsp-teams

### DIFF
--- a/modules/canary-release/main.tf
+++ b/modules/canary-release/main.tf
@@ -1,0 +1,27 @@
+resource "aws_codecommit_repository" "canary" {
+  repository_name = "gsp-canary-chart-${var.cluster_id}"
+
+  provisioner "local-exec" {
+    command = "../../../scripts/initialise_canary_helm_codecommit.sh"
+
+    environment {
+      SOURCE_REPO_URL     = "https://github.com/alphagov/gsp-canary-chart"
+      CODECOMMIT_REPO_URL = "${aws_codecommit_repository.canary.clone_url_http}"
+    }
+  }
+}
+
+module "canary-release" {
+  source = "../flux-release"
+
+  namespace  = "gsp-canary"
+  chart_git  = "${aws_codecommit_repository.canary.clone_url_http}"
+  chart_ref  = "master"
+  chart_path = "charts/gsp-canary"
+  cluster_name = ""
+  cluster_domain = "${var.cluster_id}"
+  values = <<EOF
+    updater:
+      helmChartRepoUrl: ${aws_codecommit_repository.canary.clone_url_http}
+EOF
+}

--- a/modules/canary-release/variables.tf
+++ b/modules/canary-release/variables.tf
@@ -1,0 +1,9 @@
+variable "cluster_id" {
+  type = "string"
+}
+
+variable "addons_dir" {
+  description = "local target path to place kubernetes resource yaml"
+  type        = "string"
+  default     = "addons"
+}


### PR DESCRIPTION
we want gsp-teams to be a consumer of the terraform modules only so this
moves the last remaining module for the canary into this repo