### PR TITLE
drain and delete bootstrapper node when done

### DIFF
--- a/bootstrapper/bootstrap.sh
+++ b/bootstrapper/bootstrap.sh
@@ -20,4 +20,4 @@ done
 
 aws-vault exec "${aws_vault_profile}" -- kubectl --kubeconfig kubeconfig drain --ignore-daemonsets --force --grace-period=60 -l 'node-role.kubernetes.io/bootstrapper'
 aws-vault exec "${aws_vault_profile}" -- terraform destroy -auto-approve -var "remote_state_bucket_name=${remote_state_bucket_name}" -var "remote_state_key=${remote_state_key}"
-aws-vault exec "${aws_vault_profile}" -- kubectl --kubeconfig kubeconfig delete -l 'node-role.kubernetes.io/bootstrapper'
+aws-vault exec "${aws_vault_profile}" -- kubectl --kubeconfig kubeconfig delete node -l 'node-role.kubernetes.io/bootstrapper'

--- a/bootstrapper/bootstrap.sh
+++ b/bootstrapper/bootstrap.sh
@@ -18,4 +18,6 @@ do
     sleep 10s
 done
 
+aws-vault exec "${aws_vault_profile}" -- kubectl --kubeconfig kubeconfig drain --ignore-daemonsets --force --grace-period=60 -l 'node-role.kubernetes.io/bootstrapper'
 aws-vault exec "${aws_vault_profile}" -- terraform destroy -auto-approve -var "remote_state_bucket_name=${remote_state_bucket_name}" -var "remote_state_key=${remote_state_key}"
+aws-vault exec "${aws_vault_profile}" -- kubectl --kubeconfig kubeconfig delete -l 'node-role.kubernetes.io/bootstrapper'


### PR DESCRIPTION
## What

the bootstrapper node currently remains registered as a `Node` object in the cluster... which means things like DaemonSets report back as `NodeLost`. 

This updates the bootsrapper script to `kubectl drain` and `kubectl delete node` the bootstrapper to tidy up.

`--force` and `--ignore-daemonsets` flags are used to make the drain more agressive since this node is def going away, but may not always be required.

## How to review

I have run the commands manually ... but I haven't tested the script as a whole 