### PR TITLE
Restrict access to controller to office IPs

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -50,6 +50,7 @@ module "k8s-cluster" {
   controller_instance_type = "${var.controller_instance_type}"
   worker_instance_type     = "${var.worker_instance_type}"
   s3_user_data_policy_arn  = "${aws_iam_policy.s3-user-data-policy.arn}"
+  nat_gateway_ips          = "${aws_nat_gateway.cluster.*.public_ip}"
 }
 
 module "ingress-system" {

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -17,14 +17,44 @@ resource "aws_security_group_rule" "controller-ssh" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "controller-apiserver" {
+resource "aws_security_group_rule" "controller-apiserver-office-ips" {
   security_group_id = "${aws_security_group.controller.id}"
 
   type        = "ingress"
   protocol    = "tcp"
   from_port   = 6443
   to_port     = 6443
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = "${var.api_allowed_ips}"
+}
+
+resource "aws_security_group_rule" "controller-nat-gateway-ips" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 6443
+  to_port     = 6443
+  cidr_blocks = ["${formatlist("%s/32", var.nat_gateway_ips)}"]
+}
+
+resource "aws_security_group_rule" "controller-apiserver-workers" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 6443
+  to_port                  = 6443
+  source_security_group_id = "${aws_security_group.worker.id}"
+}
+
+resource "aws_security_group_rule" "controller-apiserver-self" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 6443
+  to_port                  = 6443
+  self                     = true
 }
 
 resource "aws_security_group_rule" "controller-flannel" {

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -7,16 +7,6 @@ resource "aws_security_group" "controller" {
   tags = "${map("Name", "${var.cluster_name}-controller")}"
 }
 
-resource "aws_security_group_rule" "controller-ssh" {
-  security_group_id = "${aws_security_group.controller.id}"
-
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "controller-apiserver-office-ips" {
   security_group_id = "${aws_security_group.controller.id}"
 
@@ -184,16 +174,6 @@ resource "aws_security_group" "worker" {
   vpc_id = "${var.vpc_id}"
 
   tags = "${map("Name", "${var.cluster_name}-worker")}"
-}
-
-resource "aws_security_group_rule" "worker-ssh" {
-  security_group_id = "${aws_security_group.worker.id}"
-
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 22
-  to_port     = 22
-  cidr_blocks = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "worker-http" {

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -90,3 +90,21 @@ variable "worker_count" {
   type    = "string"
   default = "2"
 }
+
+variable "api_allowed_ips" {
+  description = "Office IPs that are allowed to talk to the k8s API, taken from the GDS wiki"
+  type = "list"
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
+variable "nat_gateway_ips" {
+  type = "list"
+}


### PR DESCRIPTION
We don't want the controllers accessible from the public internet
but just the office IPs. Workers also need to talk to the controller
instances so we allow this too.

Things we weren't sure on:
- do controllers need to be able to talk to other controllers? Things seem to be working without allowing this but we can't be 100% sure that this means it is fine