### PR TITLE
Fix lb healthchecks

### DIFF
--- a/example/cluster.tf
+++ b/example/cluster.tf
@@ -9,11 +9,11 @@ terraform {
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
-    cluster_name = "${var.cluster_name}"
-    dns_zone = "${var.cluster_zone}"
-    user_data_bucket_name = "${var.user_data_bucket_name}"
-    user_data_bucket_region = "${var.user_data_bucket_region}"
-    k8s_tag = "${var.k8s_tag}"
-    admin_role_arns = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
+  source                  = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
+  cluster_name            = "${var.cluster_name}"
+  dns_zone                = "${var.cluster_zone}"
+  user_data_bucket_name   = "${var.user_data_bucket_name}"
+  user_data_bucket_region = "${var.user_data_bucket_region}"
+  k8s_tag                 = "${var.k8s_tag}"
+  admin_role_arns         = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
 }

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -1,60 +1,60 @@
 output "bootstrap-base-userdata-source" {
-    value = "${module.gsp-cluster.bootstrap-base-userdata-source}"
+  value = "${module.gsp-cluster.bootstrap-base-userdata-source}"
 }
 
 output "bootstrap-base-userdata-verification" {
-    value = "${module.gsp-cluster.bootstrap-base-userdata-verification}"
+  value = "${module.gsp-cluster.bootstrap-base-userdata-verification}"
 }
 
 output "user-data-bucket-name" {
-    value = "${var.user_data_bucket_name}"
+  value = "${var.user_data_bucket_name}"
 }
 
 output "user-data-bucket-region" {
-    value = "${var.user_data_bucket_region}"
+  value = "${var.user_data_bucket_region}"
 }
 
 output "cluster-name" {
-    value = "${var.cluster_name}"
+  value = "${var.cluster_name}"
 }
 
 output "controller-security-group-ids" {
-    value = ["${module.gsp-cluster.controller-security-group-ids}"]
+  value = ["${module.gsp-cluster.controller-security-group-ids}"]
 }
 
 output "bootstrap-subnet-id" {
-    value = "${module.gsp-cluster.bootstrap-subnet-id}"
+  value = "${module.gsp-cluster.bootstrap-subnet-id}"
 }
 
 output "controller-instance-profile-name" {
-    value = "${module.gsp-cluster.controller-instance-profile-name}"
+  value = "${module.gsp-cluster.controller-instance-profile-name}"
 }
 
 output "apiserver-lb-target-group-arn" {
-    value = "${module.gsp-cluster.apiserver-lb-target-group-arn}"
+  value = "${module.gsp-cluster.apiserver-lb-target-group-arn}"
 }
 
 output "dns-service-ip" {
-    value = "${module.gsp-cluster.dns-service-ip}"
+  value = "${module.gsp-cluster.dns-service-ip}"
 }
 
 output "cluster-domain-suffix" {
-    value = "${module.gsp-cluster.cluster-domain-suffix}"
+  value = "${module.gsp-cluster.cluster-domain-suffix}"
 }
 
 output "k8s-tag" {
-    value = "${var.k8s_tag}"
+  value = "${var.k8s_tag}"
 }
 
 output "kubelet-kubeconfig" {
-    value = "${module.gsp-cluster.kubelet-kubeconfig}"
-    sensitive = true
+  value     = "${module.gsp-cluster.kubelet-kubeconfig}"
+  sensitive = true
 }
 
 output "admin-kubeconfig" {
-    value = "${module.gsp-cluster.admin-kubeconfig}"
+  value = "${module.gsp-cluster.admin-kubeconfig}"
 }
 
 output "kube-ca-crt" {
-    value = "${module.gsp-cluster.kube-ca-crt}"
+  value = "${module.gsp-cluster.kube-ca-crt}"
 }

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,19 +1,19 @@
 variable "user_data_bucket_name" {
-    type = "string"
+  type = "string"
 }
 
 variable "user_data_bucket_region" {
-    type = "string"
+  type = "string"
 }
 
 variable "cluster_name" {
-    type = "string"
+  type = "string"
 }
 
 variable "k8s_tag" {
-    type = "string"
+  type = "string"
 }
 
 variable "cluster_zone" {
-    type = "string"
+  type = "string"
 }

--- a/modules/bootkube-ignition/outputs.tf
+++ b/modules/bootkube-ignition/outputs.tf
@@ -74,7 +74,7 @@ output "admin-kubeconfig" {
 }
 
 output "kubelet-kubeconfig" {
-  value = "${data.template_file.kubeconfig-kubelet.rendered}"
+  value     = "${data.template_file.kubeconfig-kubelet.rendered}"
   sensitive = true
 }
 

--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -7,7 +7,7 @@ data "template_file" "flux" {
 }
 
 resource "local_file" "flux" {
-  count = "${var.enabled == 0 ? 0 : 1}"
+  count    = "${var.enabled == 0 ? 0 : 1}"
   filename = "${var.addons_dir}/flux.yaml"
   content  = "${data.template_file.flux.rendered}"
 }
@@ -21,7 +21,7 @@ data "template_file" "namespace" {
 }
 
 resource "local_file" "namespace" {
-  count = "${var.enabled == 0 ? 0 : 1}"
+  count    = "${var.enabled == 0 ? 0 : 1}"
   filename = "${var.addons_dir}/${var.namespace}-namespace.yaml"
   content  = "${data.template_file.namespace.rendered}"
 }
@@ -30,35 +30,35 @@ data "template_file" "helm-release" {
   template = "${file("${path.module}/data/helm-release.yaml")}"
 
   vars {
-    namespace  = "${var.namespace}"
-    chart_git  = "${var.chart_git}"
-    chart_ref  = "${var.chart_ref}"
-    chart_path = "${var.chart_path}"
-    cluster_name = "${var.cluster_name}"
-    cluster_domain = "${var.cluster_domain}"
-    values     = "${var.values}"
+    namespace        = "${var.namespace}"
+    chart_git        = "${var.chart_git}"
+    chart_ref        = "${var.chart_ref}"
+    chart_path       = "${var.chart_path}"
+    cluster_name     = "${var.cluster_name}"
+    cluster_domain   = "${var.cluster_domain}"
+    values           = "${var.values}"
     valueFileSecrets = "[${join(",",formatlist("{\"name\":\"%s\"}", var.valueFileSecrets))}]"
   }
 }
 
 resource "local_file" "helm-release-yaml" {
-  count = "${var.enabled == 0 ? 0 : 1}"
+  count    = "${var.enabled == 0 ? 0 : 1}"
   filename = "${var.addons_dir}/${var.namespace}-helm-release.yaml"
   content  = "${data.template_file.helm-release.rendered}"
 }
 
 data "template_file" "values" {
-  count = "${length(var.valueFileSecrets)}"
+  count    = "${length(var.valueFileSecrets)}"
   template = "${file("${path.module}/data/values-secret.yaml")}"
 
   vars {
     namespace = "${var.namespace}"
-    name = "${var.valueFileSecrets[count.index]}"
+    name      = "${var.valueFileSecrets[count.index]}"
   }
 }
 
 resource "local_file" "values" {
-  count = "${length(var.valueFileSecrets)}"
+  count    = "${length(var.valueFileSecrets)}"
   filename = "${var.addons_dir}/${var.namespace}-${var.valueFileSecrets[count.index]}-values.yaml"
   content  = "${data.template_file.values.*.rendered[count.index]}"
 }

--- a/modules/flux-release/variables.tf
+++ b/modules/flux-release/variables.tf
@@ -3,51 +3,51 @@ variable "enabled" {
 }
 
 variable "namespace" {
-    description = "namespace to deploy into"
-    type = "string"
+  description = "namespace to deploy into"
+  type        = "string"
 }
 
 variable "chart_git" {
-    description = "git repository containing helm chart to watch/deploy"
-    type = "string"
+  description = "git repository containing helm chart to watch/deploy"
+  type        = "string"
 }
 
 variable "chart_ref" {
-    description = "git ref/branch to watch"
-    type = "string"
-    default = "master"
+  description = "git ref/branch to watch"
+  type        = "string"
+  default     = "master"
 }
 
 variable "chart_path" {
-    description = "path within the git repository to a helm chart to deploy"
-    type = "string"
-    default = ""
+  description = "path within the git repository to a helm chart to deploy"
+  type        = "string"
+  default     = ""
 }
 
 variable "addons_dir" {
-    description = "local target path to place kubernetes resource yaml"
-    type = "string"
-    default = "addons"
+  description = "local target path to place kubernetes resource yaml"
+  type        = "string"
+  default     = "addons"
 }
 
 variable "values" {
-    description = "embedded yaml to pass to the helm resource for flux helm operator. Whitespace is important"
-    type = "string"
-    default = ""
+  description = "embedded yaml to pass to the helm resource for flux helm operator. Whitespace is important"
+  type        = "string"
+  default     = ""
 }
 
 variable "valueFileSecrets" {
-    description = "List of names of Secrets containing additional helm values"
-    type = "list"
-    default = []
+  description = "List of names of Secrets containing additional helm values"
+  type        = "list"
+  default     = []
 }
 
 variable "cluster_name" {
-    description = "name of this cluster/environment (accessible as .Values.cluster.name in charts)"
-    type = "string"
+  description = "name of this cluster/environment (accessible as .Values.cluster.name in charts)"
+  type        = "string"
 }
 
 variable "cluster_domain" {
-    description = "domain mapped to this cluster/environment (accessible as .Values.cluster.name in charts)"
-    type = "string"
+  description = "domain mapped to this cluster/environment (accessible as .Values.cluster.name in charts)"
+  type        = "string"
 }

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -50,7 +50,8 @@ module "k8s-cluster" {
   controller_instance_type = "${var.controller_instance_type}"
   worker_instance_type     = "${var.worker_instance_type}"
   s3_user_data_policy_arn  = "${aws_iam_policy.s3-user-data-policy.arn}"
-  apiserver_allowed_cidrs  = ["${concat(
+
+  apiserver_allowed_cidrs = ["${concat(
       list(aws_vpc.network.cidr_block),
       formatlist("%s/32", aws_nat_gateway.cluster.*.public_ip),
       var.gds_external_cidrs,
@@ -59,7 +60,7 @@ module "k8s-cluster" {
 
 module "ingress-system" {
   enabled = "${var.addons["ingress"]}"
-  source = "../flux-release"
+  source  = "../flux-release"
 
   namespace      = "ingress-system"
   chart_git      = "https://github.com/alphagov/gsp-ingress-system.git"
@@ -72,7 +73,7 @@ module "ingress-system" {
 module "monitoring-system" {
   source = "../flux-release"
 
-  enabled = "${var.addons["monitoring"]}"
+  enabled        = "${var.addons["monitoring"]}"
   namespace      = "monitoring-system"
   chart_git      = "https://github.com/alphagov/gsp-monitoring-system.git"
   chart_ref      = "master"
@@ -84,7 +85,7 @@ module "monitoring-system" {
 module "secrets-system" {
   source = "../flux-release"
 
-  enabled = "${var.addons["secrets"]}"
+  enabled        = "${var.addons["secrets"]}"
   namespace      = "secrets-system"
   chart_git      = "https://github.com/alphagov/gsp-secrets-system.git"
   chart_ref      = "master"
@@ -96,7 +97,7 @@ module "secrets-system" {
 module "ci-system" {
   source = "..//flux-release"
 
-  enabled = "${var.addons["ci"]}"
+  enabled        = "${var.addons["ci"]}"
   namespace      = "ci-system"
   chart_git      = "https://github.com/alphagov/gsp-ci-system.git"
   chart_ref      = "master"
@@ -106,7 +107,7 @@ module "ci-system" {
 }
 
 resource "aws_codecommit_repository" "canary" {
-  count = "${var.addons["canary"] ? 1 : 0}"
+  count           = "${var.addons["canary"] ? 1 : 0}"
   repository_name = "canary.${var.cluster_name}.${var.dns_zone}"
 
   provisioner "local-exec" {
@@ -122,14 +123,15 @@ resource "aws_codecommit_repository" "canary" {
 module "canary-system" {
   source = "../flux-release"
 
-  enabled = "${var.addons["canary"]}"
-  namespace  = "gsp-canary"
-  chart_git  = "${var.addons["canary"] ? element(concat(aws_codecommit_repository.canary.*.clone_url_http, list("")), 0) : ""}"
-  chart_ref  = "master"
-  chart_path = "charts/gsp-canary"
-  cluster_name = ""
+  enabled        = "${var.addons["canary"]}"
+  namespace      = "gsp-canary"
+  chart_git      = "${var.addons["canary"] ? element(concat(aws_codecommit_repository.canary.*.clone_url_http, list("")), 0) : ""}"
+  chart_ref      = "master"
+  chart_path     = "charts/gsp-canary"
+  cluster_name   = ""
   cluster_domain = "${var.cluster_name}.${var.dns_zone}"
   addons_dir     = "addons/${var.cluster_name}"
+
   values = <<EOF
     updater:
       helmChartRepoUrl: ${var.addons["canary"] ? element(concat(aws_codecommit_repository.canary.*.clone_url_http, list("")), 0) : ""}

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -50,7 +50,11 @@ module "k8s-cluster" {
   controller_instance_type = "${var.controller_instance_type}"
   worker_instance_type     = "${var.worker_instance_type}"
   s3_user_data_policy_arn  = "${aws_iam_policy.s3-user-data-policy.arn}"
-  nat_gateway_ips          = "${aws_nat_gateway.cluster.*.public_ip}"
+  apiserver_allowed_cidrs  = ["${concat(
+      list(aws_vpc.network.cidr_block),
+      formatlist("%s/32", aws_nat_gateway.cluster.*.public_ip),
+      var.gds_external_cidrs,
+  )}"]
 }
 
 module "ingress-system" {

--- a/modules/gsp-cluster/network.tf
+++ b/modules/gsp-cluster/network.tf
@@ -29,7 +29,7 @@ resource "aws_route_table" "cluster-private" {
   vpc_id = "${aws_vpc.network.id}"
 
   route {
-    cidr_block = "0.0.0.0/0"
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = "${element(aws_nat_gateway.cluster.*.id, count.index)}"
   }
 

--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -47,7 +47,7 @@ output "cluster-domain-suffix" {
 }
 
 output "kubelet-kubeconfig" {
-  value = "${module.bootkube-assets.kubelet-kubeconfig}"
+  value     = "${module.bootkube-assets.kubelet-kubeconfig}"
   sensitive = true
 }
 

--- a/modules/gsp-cluster/route53.tf
+++ b/modules/gsp-cluster/route53.tf
@@ -1,4 +1,3 @@
 data "aws_route53_zone" "zone" {
   name = "${var.dns_zone}."
 }
-

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -60,19 +60,21 @@ variable "worker_instance_type" {
 }
 
 variable "addons" {
-  type    = "map"
+  type = "map"
+
   default = {
-    ingress = 1
-    canary = 1
+    ingress    = 1
+    canary     = 1
     monitoring = 1
-    secrets = 1
-    ci = 0
+    secrets    = 1
+    ci         = 0
   }
 }
 
 variable "gds_external_cidrs" {
   description = "External GDS CIDRs that are allowed to talk to the clusters, taken from the GDS wiki"
-  type = "list"
+  type        = "list"
+
   default = [
     "213.86.153.212/32",
     "213.86.153.213/32",

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -69,3 +69,17 @@ variable "addons" {
     ci = 0
   }
 }
+
+variable "gds_external_cidrs" {
+  description = "External GDS CIDRs that are allowed to talk to the clusters, taken from the GDS wiki"
+  type = "list"
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -39,7 +39,7 @@ resource "aws_launch_configuration" "controller" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = ["image_id"]
+    ignore_changes        = ["image_id"]
   }
 
   iam_instance_profile = "${aws_iam_instance_profile.controller_profile.name}"

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -7,44 +7,14 @@ resource "aws_security_group" "controller" {
   tags = "${map("Name", "${var.cluster_name}-controller")}"
 }
 
-resource "aws_security_group_rule" "controller-apiserver-office-ips" {
+resource "aws_security_group_rule" "controller-apiserver-cidrs" {
   security_group_id = "${aws_security_group.controller.id}"
 
   type        = "ingress"
   protocol    = "tcp"
   from_port   = 6443
   to_port     = 6443
-  cidr_blocks = "${var.api_allowed_ips}"
-}
-
-resource "aws_security_group_rule" "controller-nat-gateway-ips" {
-  security_group_id = "${aws_security_group.controller.id}"
-
-  type        = "ingress"
-  protocol    = "tcp"
-  from_port   = 6443
-  to_port     = 6443
-  cidr_blocks = ["${formatlist("%s/32", var.nat_gateway_ips)}"]
-}
-
-resource "aws_security_group_rule" "controller-apiserver-workers" {
-  security_group_id = "${aws_security_group.controller.id}"
-
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 6443
-  to_port                  = 6443
-  source_security_group_id = "${aws_security_group.worker.id}"
-}
-
-resource "aws_security_group_rule" "controller-apiserver-self" {
-  security_group_id = "${aws_security_group.controller.id}"
-
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 6443
-  to_port                  = 6443
-  self                     = true
+  cidr_blocks = ["${var.apiserver_allowed_cidrs}"]
 }
 
 resource "aws_security_group_rule" "controller-flannel" {

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -46,6 +46,10 @@ variable "s3_user_data_policy_arn" {
   type = "string"
 }
 
+variable "apiserver_allowed_cidrs" {
+  type = "list"
+}
+
 variable "service_cidr" {
   type    = "string"
   default = "10.3.0.0/24"
@@ -89,22 +93,4 @@ variable "controller_count" {
 variable "worker_count" {
   type    = "string"
   default = "2"
-}
-
-variable "api_allowed_ips" {
-  description = "Office IPs that are allowed to talk to the k8s API, taken from the GDS wiki"
-  type = "list"
-  default = [
-    "213.86.153.212/32",
-    "213.86.153.213/32",
-    "213.86.153.214/32",
-    "213.86.153.235/32",
-    "213.86.153.236/32",
-    "213.86.153.237/32",
-    "85.133.67.244/32",
-  ]
-}
-
-variable "nat_gateway_ips" {
-  type = "list"
 }


### PR DESCRIPTION
Since the "allowed ips" changes went in the NLB target groups for the kube-apiserver were permanently "unhealthy". This simplifies the security group rules while fixing that problem.

Probably best to review only the commit with the changes as the `terraform fmt` commit modifies lots of unrelated files with whitespace changes.

Solo: @blairboy362 
