### PR TITLE
Add lambda to optionally ship cloudwatch logs to splunk

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -100,6 +100,17 @@ resource "aws_cloudwatch_log_group" "logs" {
   retention_in_days = 30
 }
 
+module "lambda_splunk_forwarder" {
+  source = "../lambda_splunk_forwarder"
+
+  enabled                   = "${var.addons["splunk"]}"
+  cloudwatch_log_group_arn  = "${aws_cloudwatch_log_group.logs.arn}"
+  cloudwatch_log_group_name = "${aws_cloudwatch_log_group.logs.name}"
+  cluster_name              = "${var.cluster_name}"
+  splunk_hec_token          = "${var.splunk_hec_token}"
+  splunk_hec_url            = "${var.splunk_hec_url}"
+}
+
 module "secrets-system" {
   source = "../flux-release"
 

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -74,6 +74,7 @@ variable "addons" {
     monitoring = 1
     secrets    = 1
     ci         = 0
+    splunk     = 0
   }
 }
 
@@ -95,4 +96,16 @@ variable "gds_external_cidrs" {
 variable "dev_namespaces" {
   type    = "list"
   default = []
+}
+
+variable "splunk_hec_token" {
+  description = "Splunk HTTP event collector token for authentication"
+  type        = "string"
+  default     = ""
+}
+
+variable "splunk_hec_url" {
+  description = "Splunk HTTP event collector URL to send logs to"
+  type        = "string"
+  default     = ""
 }

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -102,6 +102,6 @@ variable "api_allowed_ips" {
 }
 
 variable "nat_gateway_ips" {
-  type = "list"
-  default     = []
+  type    = "list"
+  default = []
 }

--- a/modules/lambda_splunk_forwarder/iam.tf
+++ b/modules/lambda_splunk_forwarder/iam.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_role" "lambda_log_forwarder" {
+  count              = "${var.enabled == 0 ? 0 : 1}"
+  name               = "${var.cluster_name}_lambda_log_forwarder"
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_log_forwarder_assume_role_policy.json}"
+}
+
+resource "aws_iam_policy_attachment" "lambda_log_forwarder" {
+  count      = "${var.enabled == 0 ? 0 : 1}"
+  name       = "${var.cluster_name}_lambda_log_forwarder_attachment"
+  roles      = ["${aws_iam_role.lambda_log_forwarder.name}"]
+  policy_arn = "${aws_iam_policy.lambda_log_forwarder.arn}"
+}
+
+resource "aws_iam_policy" "lambda_log_forwarder" {
+  count       = "${var.enabled == 0 ? 0 : 1}"
+  name        = "${var.cluster_name}_lambda_log_forwarder"
+  description = "Policy for Lambda log forwarding function"
+  policy      = "${data.aws_iam_policy_document.lambda_log_forwarder.json}"
+}
+
+data "aws_iam_policy_document" "lambda_log_forwarder" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "lambda_log_forwarder_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}

--- a/modules/lambda_splunk_forwarder/index.js
+++ b/modules/lambda_splunk_forwarder/index.js
@@ -1,0 +1,61 @@
+/**
+ * Stream events from AWS CloudWatch Logs to Splunk
+ *
+ * This function streams AWS CloudWatch Logs to Splunk using
+ * Splunk's HTTP event collector API.
+ *
+ * Define the following Environment Variables in the console below to configure
+ * this function to stream logs to your Splunk host:
+ *
+ * 1. SPLUNK_HEC_URL: URL address for your Splunk HTTP event collector endpoint.
+ * Default port for event collector is 8088. Example: https://host.com:8088/services/collector
+ *
+ * 2. SPLUNK_HEC_TOKEN: Token for your Splunk HTTP event collector.
+ * To create a new token for this Lambda function, refer to Splunk Docs:
+ * http://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#Create_an_Event_Collector_token
+ */
+
+'use strict';
+
+const loggerConfig = {
+    url: process.env.SPLUNK_HEC_URL || 'https://<HOST>:<PORT>/services/collector',
+    token: process.env.SPLUNK_HEC_TOKEN || '<TOKEN>',
+};
+
+const SplunkLogger = require('./lib/mysplunklogger');
+const zlib = require('zlib');
+
+const logger = new SplunkLogger(loggerConfig);
+
+exports.handler = (event, context, callback) => {
+    // CloudWatch Logs data is base64 encoded so decode here
+    const payload = Buffer.from(event.awslogs.data, 'base64');
+    zlib.gunzip(payload, (err, result) => {
+        if (err) {
+            callback(err);
+        } else {
+            const parsed = JSON.parse(result.toString('ascii'));
+            console.log('Event Data:', JSON.stringify(parsed, null, 2));
+            let count = 0;
+            if (parsed.logEvents) {
+                parsed.logEvents.forEach((item) => {
+                    // Send item JSON object (optional 'context' arg used to add Lambda metadata e.g. awsRequestId, functionName)
+                    // Change "item.timestamp" below if time is specified in another field in the event
+                    // Change to "logger.log(item.message, context)" if no time field is present in event
+                    logger.logWithTime(item.timestamp, item.message, context);
+                    count += 1;
+                });
+            }
+            // Send all the events in a single batch to Splunk
+            logger.flushAsync((error, response) => {
+                if (error) {
+                    callback(error);
+                } else {
+                    console.log(`Response from Splunk:\n${response}`);
+                    console.log(`Successfully processed ${count} log event(s).`);
+                    callback(null, count); // Return number of log events
+                }
+            });
+        }
+    });
+};

--- a/modules/lambda_splunk_forwarder/lambda.tf
+++ b/modules/lambda_splunk_forwarder/lambda.tf
@@ -1,0 +1,49 @@
+resource "null_resource" "create_lambda_zip_file" {
+  provisioner "local-exec" {
+    command = "cd ${path.module}; rm -f *.zip; zip -q -r lambda_log_forwarder.zip lib index.js"
+  }
+}
+
+resource "aws_lambda_function" "lambda_log_forwarder" {
+  count         = "${var.enabled == 0 ? 0 : 1}"
+  depends_on    = ["null_resource.create_lambda_zip_file"]
+  filename      = "${path.module}/lambda_log_forwarder.zip"
+  function_name = "${var.cluster_name}_log_forwarder"
+  role          = "${aws_iam_role.lambda_log_forwarder.arn}"
+  handler       = "index.handler"
+  runtime       = "nodejs6.10"
+  timeout       = "10"
+  memory_size   = "128"
+  description   = "A function to forward logs from AWS to a Splunk HEC"
+
+  environment {
+    variables = {
+      SPLUNK_HEC_TOKEN = "${var.splunk_hec_token}"
+      SPLUNK_HEC_URL   = "${var.splunk_hec_url}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "lambda_log_forwarder" {
+  count             = "${var.enabled == 0 ? 0 : 1}"
+  name              = "/aws/lambda/${aws_lambda_function.lambda_log_forwarder.function_name}"
+  retention_in_days = 7
+}
+
+resource "aws_lambda_permission" "cloudwatch_splunk_logs" {
+  count         = "${var.enabled == 0 ? 0 : 1}"
+  statement_id  = "${var.cluster_name}_cloudwatch_splunk_logs"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.lambda_log_forwarder.arn}"
+  principal     = "logs.eu-west-2.amazonaws.com"
+  source_arn    = "${var.cloudwatch_log_group_arn}"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_splunk_logs" {
+  count           = "${var.enabled == 0 ? 0 : 1}"
+  depends_on      = ["aws_lambda_permission.cloudwatch_splunk_logs"]
+  name            = "${var.cluster_name}_cloudwatch_splunk_logs_subscription_filter"
+  destination_arn = "${aws_lambda_function.lambda_log_forwarder.arn}"
+  filter_pattern  = ""
+  log_group_name  = "${var.cloudwatch_log_group_name}"
+}

--- a/modules/lambda_splunk_forwarder/lib/mysplunklogger.js
+++ b/modules/lambda_splunk_forwarder/lib/mysplunklogger.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const url = require('url');
+
+const Logger = function Logger(config) {
+    this.url = config.url;
+    this.token = config.token;
+
+    this.addMetadata = true;
+    this.setSource = true;
+
+    this.parsedUrl = url.parse(this.url);
+    // eslint-disable-next-line import/no-dynamic-require
+    this.requester = require(this.parsedUrl.protocol.substring(0, this.parsedUrl.protocol.length - 1));
+    // Initialize request options which can be overridden & extended by consumer as needed
+    this.requestOptions = {
+        hostname: this.parsedUrl.hostname,
+        path: this.parsedUrl.path,
+        port: this.parsedUrl.port,
+        method: 'POST',
+        headers: {
+            Authorization: `Splunk ${this.token}`,
+        },
+        rejectUnauthorized: false,
+    };
+
+    this.payloads = [];
+};
+
+// Simple logging API for Lambda functions
+Logger.prototype.log = function log(message, context) {
+    this.logWithTime(Date.now(), message, context);
+};
+
+Logger.prototype.logWithTime = function logWithTime(time, message, context) {
+    const payload = {};
+
+    if (Object.prototype.toString.call(message) === '[object Array]') {
+        throw new Error('message argument must be a string or a JSON object.');
+    }
+    payload.event = message;
+
+    // Add Lambda metadata
+    if (typeof context !== 'undefined') {
+        if (this.addMetadata) {
+            // Enrich event only if it is an object
+            if (message === Object(message)) {
+                payload.event = JSON.parse(JSON.stringify(message)); // deep copy
+                payload.event.awsRequestId = context.awsRequestId;
+            }
+        }
+        if (this.setSource) {
+            payload.source = `lambda:${context.functionName}`;
+        }
+    }
+
+    payload.time = new Date(time).getTime() / 1000;
+
+    this.logEvent(payload);
+};
+
+Logger.prototype.logEvent = function logEvent(payload) {
+    this.payloads.push(JSON.stringify(payload));
+};
+
+Logger.prototype.flushAsync = function flushAsync(callback) {
+    callback = callback || (() => {}); // eslint-disable-line no-param-reassign
+
+    console.log('Sending event');
+    const req = this.requester.request(this.requestOptions, (res) => {
+        res.setEncoding('utf8');
+
+        console.log('Response received');
+        res.on('data', (data) => {
+            let error = null;
+            if (res.statusCode !== 200) {
+                error = new Error(`error: statusCode=${res.statusCode}\n\n${data}`);
+                console.error(error);
+            } else {
+                console.log('Sent');
+            }
+            this.payloads.length = 0;
+            callback(error, data);
+        });
+    });
+
+    req.on('error', (error) => {
+        callback(error);
+    });
+
+    req.end(this.payloads.join(''), 'utf8');
+};
+
+module.exports = Logger;

--- a/modules/lambda_splunk_forwarder/variables.tf
+++ b/modules/lambda_splunk_forwarder/variables.tf
@@ -1,0 +1,27 @@
+variable "enabled" {
+  default = 1
+}
+
+variable "cloudwatch_log_group_arn" {
+  description = "The ARN of the cloudwatch log group to ship to Splunk"
+  type        = "string"
+}
+
+variable "cloudwatch_log_group_name" {
+  description = "The name of the cloudwatch log group to ship to Splunk"
+  type        = "string"
+}
+
+variable "cluster_name" {
+  type = "string"
+}
+
+variable "splunk_hec_token" {
+  description = "Splunk HTTP event collector token for authentication"
+  type        = "string"
+}
+
+variable "splunk_hec_url" {
+  description = "Splunk HTTP event collector URL to send logs to"
+  type        = "string"
+}


### PR DESCRIPTION
https://trello.com/c/qboQ4xcn/223-ship-logs-from-cloudwatch-into-splunk

- Decision was made to have one lambda per cluster rather than
one lambda per account. This is because the cloudwatch log
group to ship is set up with each cluster and is not known
by the account

- Default is not to ship logs to splunk for the moment as dev
stacks will not need to and EIDAS  only want to ship prod
logs rather than staging (although also want to ship staging
whilst the pen test is ongoing).

The code has been adapted from https://github.com/deliveryhero/dhh-system-engineering/tree/master/terraform/aws/modules/lambda_splunk_forwarder.
Whilst I tried to avoid diverging from the module, I ended up
bringing the code into our repository and adapting it. The reasons
for this are
- there is no way to optionally include a module as per https://github.com/hashicorp/terraform/issues/953
meaning that we can not turn the module on and off for dev/prod
stacks
- As we may be running multiple lambdas per AWS account they need
to have independant resource names so we make them unique by passing
the cluster name in as a variable
- Lambda names which contain the cluster name will be shown
as the source for splunk events, meaning we can differentiate
between clusters.
- Cyber security believe they will need to make changes to the
lambda file in the near future

Our lambdas create their own logs themselves which go into
Cloudwatch. I am not sure if this is of particular benefit but I
have kept this behaviour as it existed in `dhh-system-engineering`.

### TODO
Corresponding PR for gsp-teams which turns on splunk log shipping for eidas staging environment as asked by Alex from Cyber Sec


### Picture of logs arriving in Splunk from my dev stack
![image](https://user-images.githubusercontent.com/7228605/51756472-fb146580-20b8-11e9-84fe-94b8f3f33e72.png)
