### PR TITLE
Provide real fallback defaults for addons

### DIFF
--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -68,14 +68,7 @@ variable "worker_instance_type" {
 variable "addons" {
   type = "map"
 
-  default = {
-    ingress    = 1
-    canary     = 1
-    monitoring = 1
-    secrets    = 1
-    ci         = 0
-    splunk     = 0
-  }
+  default = {}
 }
 
 variable "gds_external_cidrs" {


### PR DESCRIPTION
## What

When we implement a new feature right now, say add `splunk` into the mix,
we will break any other cluster setup that currently doesn't have that
key embedded.

Instead, we could be having defaults as a different map, and attempt to
merge them when necessary to avoid breaking the cluster.

## How to review

- Code review - see if I haven't missed `s/var.addons/local.enabled_addons/g`
- Run `terraform apply` against your cluster
  - would be good to remove some of the default values
  - This could be tested by:
    - just modifying the `cluster.tf`
    - running `terraform init -upgrade=true`
    - running `terraform plan`
    - expect `No changes`
