### PR TITLE
Create ssh key so CI can write to github repos

### DIFF
--- a/modules/gsp-cluster/data/ci-secrets.yaml
+++ b/modules/gsp-cluster/data/ci-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ci-github-key
+  namespace: ${namespace}
+data:
+  private_key: |
+    ${private_key}

--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -90,3 +90,7 @@ output "notary-targets-passphrase" {
 output "harbor-password" {
   value = "${base64encode(random_string.harbor_password.result)}"
 }
+
+output "github-deployment-public-key" {
+  value = "${tls_private_key.github_deployment_key.public_key_openssh}"
+}


### PR DESCRIPTION
https://trello.com/c/nZqPwMsF/112-create-a-pipeline-for-promoting-deployment-charts-between-environments

Given that CI pipelines will exist in the default concourse
team (called `main`), k8s secrets that need to be available to
concourse must be placed in the `ci-system-main` namespace.
This is documented in the concourse chart:
https://github.com/helm/charts/tree/master/stable/concourse#kubernetes-secrets

This key is also outputted from the gsp-cluster module as it will
need to be manually copied by a developer and added as a
deployment key with read/write access to the repository which we
allow our CI to have write access to.

This will allow our CI to tag repositories as part of our
deployment pipeline, tagging a `staging` and `production` branch.