### PR TITLE
Fallback to namespace

### DIFF
--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -52,5 +52,5 @@ resource "local_file" "values" {
 }
 
 output "release-name" {
-  value = "${var.release_name}"
+  value = "${coalesce(var.release_name, var.namespace)}"
 }


### PR DESCRIPTION
## What

We're now supporting the fallback functionality when it comes to setting
the release_name. This has however been omitted when we need to output
the variable to different means.