### PR TITLE
Fix permissions for the canary code commit initialisation script.

### DIFF
--- a/modules/gsp-canary/main.tf
+++ b/modules/gsp-canary/main.tf
@@ -5,8 +5,9 @@ resource "aws_codecommit_repository" "canary" {
     command = "${path.module}/scripts/initialise_canary_helm_codecommit.sh"
 
     environment {
-      SOURCE_REPO_URL     = "https://github.com/alphagov/gsp-canary-chart"
-      CODECOMMIT_REPO_URL = "${aws_codecommit_repository.canary.clone_url_http}"
+      SOURCE_REPO_URL          = "https://github.com/alphagov/gsp-canary-chart"
+      CODECOMMIT_REPO_URL      = "${aws_codecommit_repository.canary.clone_url_http}"
+      CODECOMMIT_INIT_ROLE_ARN = "${var.codecommit_init_role_arn}"
     }
   }
 }

--- a/modules/gsp-canary/variables.tf
+++ b/modules/gsp-canary/variables.tf
@@ -16,3 +16,8 @@ variable "canary_role_assumer_arn" {
   description = "ARN of the role assuming the canary role, e.g. kiam-server-role"
   type        = "string"
 }
+
+variable "codecommit_init_role_arn" {
+  type    = "string"
+  default = ""
+}

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -251,9 +251,10 @@ module "group-role-bindings" {
 }
 
 module "gsp-canary" {
-  source                  = "../gsp-canary"
-  cluster_name            = "${var.cluster_name}"
-  dns_zone                = "${var.dns_zone}"
-  addons_dir              = "addons/${var.cluster_name}"
-  canary_role_assumer_arn = "${aws_iam_role.kiam_server_role.arn}"
+  source                   = "../gsp-canary"
+  cluster_name             = "${var.cluster_name}"
+  dns_zone                 = "${var.dns_zone}"
+  addons_dir               = "addons/${var.cluster_name}"
+  canary_role_assumer_arn  = "${aws_iam_role.kiam_server_role.arn}"
+  codecommit_init_role_arn = "${var.codecommit_init_role_arn}"
 }

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -102,3 +102,8 @@ variable "splunk_hec_url" {
   type        = "string"
   default     = ""
 }
+
+variable "codecommit_init_role_arn" {
+  type    = "string"
+  default = ""
+}


### PR DESCRIPTION
During initialisation when terraform local-exec's the script to bootstrap
the code commit repo the script itself hasn't assumed the appropriate role
(as terraform has). So, an explicit assume role needs to happen.

Solo: @blairboy362 