### PR TITLE
Allow sed work cross OS

### DIFF
--- a/modules/gsp-canary/scripts/initialise_canary_helm_codecommit.sh
+++ b/modules/gsp-canary/scripts/initialise_canary_helm_codecommit.sh
@@ -46,7 +46,7 @@ fi
 git branch -u source/master
 
 # update the embedded timestamp
-sed -i "" -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" charts/gsp-canary/values.yaml
+sed -i.bak -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" charts/gsp-canary/values.yaml
 git add charts/gsp-canary/values.yaml
 git commit -m "Initial timestamp update."
 git push --force destination master


### PR DESCRIPTION
## What

Whilst the command works beautifully on macOS, I'm not sure how did it
ever work in the docker container in the pipeline.

The Linux version of sed doesn't understand the empty string straight
after the `-i` flag unless the empty white space would not be present.

The macOS version, will be happy with the said white space but it will
throw up if it's missing...

Since we're deliberately `git add`ing the file we want in the shell
script, we can make the best of both world and convert the flag to
`-i.bak`, which as a side effect will create a backup file, but will
work on either OS.

I care about both OS, as the script is ran in the pipeline (Linux) for
automated deployment, but also on our local machines (most likely
macOS), to spin the personal cluster up.

## How to review

- Run command on your machine
- Run command on a docker machine
  ```sh
  docker run -it nginx bash
  apt update && apt install git -y
  git clone https://github.com/alphagov/gsp-canary-chart.git
  cd gsp-canary-chart
  # The command
  ```