### PR TITLE
Disable data resource generation by default

### DIFF
--- a/modules/gsp-ci/iam.tf
+++ b/modules/gsp-ci/iam.tf
@@ -26,8 +26,8 @@ data "aws_iam_policy_document" "harbor-s3" {
     ]
 
     resources = [
-      "${element(aws_s3_bucket.ci-system-harbor-registry-storage.*.arn, 0)}",
-      "${element(aws_s3_bucket.ci-system-harbor-registry-storage.*.arn, 0)}/*",
+      "${element(concat(aws_s3_bucket.ci-system-harbor-registry-storage.*.arn, list("")), 0)}",
+      "${element(concat(aws_s3_bucket.ci-system-harbor-registry-storage.*.arn, list("")), 0)}/*",
     ]
   }
 }


### PR DESCRIPTION
## What

Right now, if the CI module is disabled in the terraform, it will fail
to run the `apply` action due to an empty array and code "compilation".

Appending every array with an empty entry should fix that issue.

## How to review

- Seek sense in my thinking
- Attempt to build non-ci cluster from master - `terraform plan`
- Attempt to build non-ci cluster from this branch - `terraform plan`