### PR TITLE
Bump the key bits

### DIFF
--- a/modules/bootkube-ignition/tls-iam.tf
+++ b/modules/bootkube-ignition/tls-iam.tf
@@ -1,6 +1,6 @@
 resource "tls_private_key" "iam-authenticator" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 resource "tls_cert_request" "iam-authenticator" {

--- a/modules/bootkube-ignition/tls-k8s.tf
+++ b/modules/bootkube-ignition/tls-k8s.tf
@@ -1,6 +1,6 @@
 resource "tls_private_key" "kube-ca" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "ca-key" {
@@ -44,7 +44,7 @@ data "ignition_file" "ca-crt" {
 
 resource "tls_private_key" "apiserver" {
   algorithm = "${tls_private_key.kube-ca.algorithm}"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "apiserver-key" {
@@ -106,7 +106,7 @@ data "ignition_file" "apiserver-crt" {
 
 resource "tls_private_key" "service-account" {
   algorithm = "RSA"
-  rsa_bits  = 2048
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "service-account-key" {
@@ -131,7 +131,7 @@ data "ignition_file" "service-account-pub" {
 
 resource "tls_private_key" "kubelet" {
   algorithm = "RSA"
-  rsa_bits  = 2048
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "admin-key" {

--- a/modules/etcd-cluster/tls.tf
+++ b/modules/etcd-cluster/tls.tf
@@ -1,6 +1,6 @@
 resource "tls_private_key" "etcd-ca" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 resource "tls_self_signed_cert" "etcd-ca" {
@@ -84,7 +84,7 @@ data "ignition_file" "etcd-etcd-peer-ca-crt" {
 
 resource "tls_private_key" "etcd-client" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "etcd-client-key" {
@@ -164,7 +164,7 @@ data "ignition_file" "etcd-etcd-client-crt" {
 
 resource "tls_private_key" "etcd-server" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "etcd-server-key" {
@@ -244,7 +244,7 @@ data "ignition_file" "etcd-etcd-server-crt" {
 
 resource "tls_private_key" "etcd-peer" {
   algorithm = "RSA"
-  rsa_bits  = "2048"
+  rsa_bits  = 4096
 }
 
 data "ignition_file" "etcd-peer-key" {


### PR DESCRIPTION
## What

Cyber has advised us to use the more secure version of RSA. Cannot
really think of a reason not to increase these either.

## How to review

- Sanity check
- Optionally run against your cluster
