### PR TITLE
Persist key for SealedSecrets

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -148,6 +148,12 @@ module "secrets-system" {
   cluster_name   = "${var.cluster_name}"
   cluster_domain = "${var.cluster_name}.${var.dns_zone}"
   addons_dir     = "addons/${var.cluster_name}"
+
+  values = <<EOF
+  encryption:
+    public_certificate: ${base64encode(tls_self_signed_cert.sealed-secrets-certificate.cert_pem)}
+    private_key: ${base64encode(tls_private_key.sealed-secrets-key.private_key_pem)}
+EOF
 }
 
 module "kiam-system" {

--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -98,3 +98,7 @@ output "harbor-password" {
 output "github-deployment-public-key" {
   value = "${tls_private_key.github_deployment_key.public_key_openssh}"
 }
+
+output "sealed-secrets-certificate" {
+  value = "${tls_self_signed_cert.sealed-secrets-certificate.cert_pem}"
+}

--- a/modules/gsp-cluster/secrets.tf
+++ b/modules/gsp-cluster/secrets.tf
@@ -1,0 +1,25 @@
+resource "tls_private_key" "sealed-secrets-key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "tls_self_signed_cert" "sealed-secrets-certificate" {
+  key_algorithm   = "${tls_private_key.sealed-secrets-key.algorithm}"
+  private_key_pem = "${tls_private_key.sealed-secrets-key.private_key_pem}"
+
+  subject {
+    common_name  = "${var.cluster_name}.${var.dns_zone}"
+    organization = "Government Digital Service"
+  }
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+  ]
+}


### PR DESCRIPTION
## What

We'd like to avoid the need of re-encrypting the secrets if say a
cluster had to be re-built.

This will make it harder to rotate that key for the cluster, as the code
will have to be commented out, applied and then destroyed, but it's a
necessary evil.

This also means that when any plan that includes a destroy of this
resource will return an error message, which is going to affect our
pipelines and perhaps cause a lot of confusion when the day comes.

It should however mean, that the actual key is going to persist in
terraform state file.

## How to review

1. Code review
1. Spin up the cluster pointing to this branch
1. Seal a random thing
1. Apply sealed secret to the cluster
1. See if it's decrypted properly
1. Tear down the cluster (should fail on that two resources)
1. Spin up the cluster pointing to this branch (again)
1. Repeat steps 4-6

## Before merge

- Remove the TMP commit

## After merge

- Deployment pipelines will need manual trigger