### PR TITLE
Allow disabling destroy prevention

### DIFF
--- a/modules/gsp-cluster/secrets.tf
+++ b/modules/gsp-cluster/secrets.tf
@@ -3,7 +3,7 @@ resource "tls_private_key" "sealed-secrets-key" {
   rsa_bits  = 4096
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = "${var.prevent_sealed_secret_destroy}"
   }
 }
 

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -113,3 +113,8 @@ variable "codecommit_init_role_arn" {
   type    = "string"
   default = ""
 }
+
+variable "prevent_sealed_secret_destroy" {
+  description = "Prevent the `terraform destroy` action to take affect when protecting sealed secret key resource"
+  default     = true
+}


### PR DESCRIPTION
## What

Our sandbox accounts suffer from not being able to be torn down. We can
fix that by pointing to a different branch that will disable the
prevention.

If that's the case, we can provide the terraform with a variable, that
will set it for us. By default, prevent deletion, but if it's a sandbox
correctly configured, it should have an additional flag.

## How to review

- Sanity check
- Optionally, setup your cluster with additional flag and tear it down

## How to use

- Add `prevent_sealed_secret_destroy = true` to your `gsp-cluster` module configuration in `gsp-teams`