### PR TITLE
Upgrade to the latest version of `cert-manager`

### DIFF
--- a/modules/flux-release/data/namespace.yaml
+++ b/modules/flux-release/data/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: ${namespace}
   annotations:
     iam.amazonaws.com/permitted: "${permitted_roles_regex}"
+${extra_namespace_configuration}

--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -4,6 +4,7 @@ data "template_file" "namespace" {
   vars {
     permitted_roles_regex = "${var.permitted_roles_regex}"
     namespace             = "${var.namespace}"
+    extra_namespace_configuration = "${var.extra_namespace_configuration}"
   }
 }
 

--- a/modules/flux-release/variables.tf
+++ b/modules/flux-release/variables.tf
@@ -62,3 +62,8 @@ variable "permitted_roles_regex" {
   type    = "string"
   default = ""
 }
+
+variable "extra_namespace_configuration" {
+  type    = "string"
+  default = ""
+}

--- a/modules/gsp-cluster/data/cert-manager-crds.yaml
+++ b/modules/gsp-cluster/data/cert-manager-crds.yaml
@@ -1,0 +1,140 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+    priority: 1
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+    priority: 1
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced
+
+---

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -94,6 +94,22 @@ module "ingress-system" {
   cluster_name   = "${var.cluster_name}"
   cluster_domain = "${var.cluster_name}.${var.dns_zone}"
   addons_dir     = "addons/${var.cluster_name}"
+
+  extra_namespace_configuration = <<EOF
+  labels:
+    certmanager.k8s.io/disable-validation: "true"
+EOF
+
+  values = <<EOF
+    webhook:
+      enabled: false
+EOF
+}
+
+resource "local_file" "cert-manager-crds" {
+  count    = "${local.enabled_addons["ingress"]}"
+  filename = "addons/${var.cluster_name}/cert-manager-crds.yaml"
+  content  = "${file("${path.module}/data/cert-manager-crds.yaml")}"
 }
 
 module "monitoring-system" {


### PR DESCRIPTION
- We need to apply the `cert-manager` CRDs ourselves [1].

- We have to disable some `cert-manager`-specific validation in the
`ingress-system` namespace [1].

- We have disabled the webhook. The webhook currently fails to install
and was not installed by default in version 0.5.2 of the `cert-manager`
chart. It appears as though enabling Aggregation Layer Routing may solve
the problem [2,3].

[1] https://github.com/helm/charts/blob/2978da57109b37351f9d032fb0a73a976e56cf20/stable/cert-manager/README.md#installing-the-chart
[2] https://github.com/jetstack/cert-manager/issues/1220
[3] https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/#enable-kubernetes-apiserver-flags