### PR TITLE
Expose worker's security groups

### DIFF
--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -10,6 +10,10 @@ output "controller-security-group-ids" {
   value = ["${module.k8s-cluster.controller-security-group-ids}"]
 }
 
+output "worker-security-group-ids" {
+  value = ["${module.k8s-cluster.worker-security-group-ids}"]
+}
+
 output "bootstrap-subnet-id" {
   value = "${element(aws_subnet.cluster-private.*.id, 0)}"
 }

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -2,6 +2,10 @@ output "controller-security-group-ids" {
   value = ["${aws_security_group.controller.id}"]
 }
 
+output "worker-security-group-ids" {
+  value = ["${aws_security_group.worker.id}"]
+}
+
 output "controller-instance-profile-name" {
   value = "${aws_iam_instance_profile.controller_profile.name}"
 }


### PR DESCRIPTION
We need to allow HSM Client (hosted on the worker) to interact with the
HSM itself. This runs on a private network, meaning we need to allow
some inbound access.