### PR TITLE
Enable webhook authentication and authorisation for the kubelet.

### DIFF
--- a/modules/k8s-node-ignition/data/kubelet.service
+++ b/modules/k8s-node-ignition/data/kubelet.service
@@ -33,6 +33,8 @@ ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --anonymous-auth=false \
+  --authentication-token-webhook=true \
+  --authorization-mode=Webhook \
   --cert-dir=/var/lib/kubelet/pki \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --cloud-provider=aws \


### PR DESCRIPTION
Kubernetes is deprecating the read-only, insecure kubelet port in favour
of the secured port. This allows prometheus to monitor the state of the
kubelets properly.