### PR TITLE
Upgrade Flux and add Flux-Reporter

### DIFF
--- a/modules/gsp-cluster/data/flux-reporter.yaml
+++ b/modules/gsp-cluster/data/flux-reporter.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flux-reporter
+  namespace: ${namespace}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flux-reporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: flux-reporter
+    spec:
+      serviceAccount: flux
+      containers:
+        - name: flux-reporter
+          image: govsvc/gsp-deployment-report:0.0.1551810425
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flux-reporter
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: flux-reporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: flux-reporter
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: flux-reporter
+  namespace: ${namespace}
+  labels:
+    app.kubernetes.io/name: flux-reporter
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+    - hosts:
+        - flux-reporter.${cluster_domain}
+      secretName: flux-reporter-tls
+  rules:
+    - host: "flux-reporter.${cluster_domain}"
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: flux-reporter
+              servicePort: http

--- a/modules/gsp-cluster/data/flux.yaml
+++ b/modules/gsp-cluster/data/flux.yaml
@@ -173,6 +173,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --charts-sync-interval=1m
+        - --update-chart-deps=false
         resources:
           requests:
             cpu: 50m

--- a/modules/gsp-cluster/data/flux.yaml
+++ b/modules/gsp-cluster/data/flux.yaml
@@ -169,7 +169,7 @@ spec:
         # There are no ":latest" images for helm-operator. Find the most recent
         # release or image version at https://quay.io/weaveworks/helm-operator
         # and replace the tag here.
-        image: govsvc/aws-flux-helm-operator:0.0.1547744608
+        image: govsvc/aws-flux-helm-operator:0.0.1551810282
         imagePullPolicy: IfNotPresent
         args:
         - --charts-sync-interval=1m

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -84,6 +84,20 @@ resource "local_file" "flux" {
   content  = "${data.template_file.flux.rendered}"
 }
 
+data "template_file" "flux-reporter" {
+  template = "${file("${path.module}/data/flux-reporter.yaml")}"
+
+  vars {
+    namespace      = "flux-system"
+    cluster_domain = "${var.cluster_name}.${var.dns_zone}"
+  }
+}
+
+resource "local_file" "flux-reporter" {
+  filename = "addons/${var.cluster_name}/flux-reporter.yaml"
+  content  = "${data.template_file.flux-reporter.rendered}"
+}
+
 module "ingress-system" {
   enabled = "${local.enabled_addons["ingress"]}"
   source  = "../flux-release"


### PR DESCRIPTION
## What

We'd like to be running a version of flux that will tell us exact commit
that is running at the current time on the cluster.

It targets the PR we have raised, and hopefully should soon be
pointing back to upstream images...

As part of flux deployment, we'd be running the reporter application to
monitor what is currently deployed.

This should in future be built from a chart along with the flux, but
we're not there yet.

It has became a problem since version [0.5.2][1], where there was a change
to when how flux will run `helm update`. This is causing a problem with
fluentd-cloudwatch dependency as it's an incubator project...

We don't care for the updates done automatically by flux. We'd like to
disable this.

This however highlights the problem, that we have a hardcoded set of
charts for flux, meaning it's difficult to upgrade and maintain. Need to
address in a near future.

## How to review

- Code review
- Spin up cluster pointing to this branch
- See things work

[1]: https://github.com/weaveworks/flux/releases/tag/helm-0.5.2