### PR TITLE
Add role for general SRE use

### DIFF
--- a/modules/bootkube-ignition/data/manifests/aws-iam-authenticator-cfg.yaml
+++ b/modules/bootkube-ignition/data/manifests/aws-iam-authenticator-cfg.yaml
@@ -18,4 +18,5 @@ data:
       #  2) "{{SessionName}}" is the role session name.
       mapRoles:
 ${iam_admin_role_mappings}
+${iam_sre_role_mappings}
 ${iam_dev_role_mappings}

--- a/modules/bootkube-ignition/manifests.tf
+++ b/modules/bootkube-ignition/manifests.tf
@@ -4,6 +4,7 @@ data "template_file" "aws-iam-authenticator-cfg" {
   vars {
     cluster_id              = "${var.cluster_id}"
     iam_admin_role_mappings = "${join("\n", formatlist(var.admin_role_arn_mapping_template, var.admin_role_arns))}"
+    iam_sre_role_mappings   = "${join("\n", formatlist(var.sre_role_arn_mapping_template, var.sre_role_arns))}"
     iam_dev_role_mappings   = "${join("\n", formatlist(var.dev_role_arn_mapping_template, var.dev_role_arns))}"
   }
 }

--- a/modules/bootkube-ignition/variables.tf
+++ b/modules/bootkube-ignition/variables.tf
@@ -39,6 +39,11 @@ variable "admin_role_arns" {
   type        = "list"
 }
 
+variable "sre_role_arns" {
+  description = "A list of ARNs that will be mapped to cluster sre sre-administrators"
+  type        = "list"
+}
+
 variable "admin_role_arn_mapping_template" {
   description = "The template that renders into yaml for the aws iam authenticator. Whitespace is important here."
   type        = "string"
@@ -48,6 +53,18 @@ variable "admin_role_arn_mapping_template" {
         username: admin
         groups:
         - system:masters
+TEMPLATE
+}
+
+variable "sre_role_arn_mapping_template" {
+  description = "The template that renders into yaml for the aws iam authenticator. Whitespace is important here."
+  type        = "string"
+
+  default = <<TEMPLATE
+      - roleARN: %s
+        username: sre
+        groups:
+        - sre
 TEMPLATE
 }
 

--- a/modules/gsp-cluster/data/sre-cluster-role.yaml
+++ b/modules/gsp-cluster/data/sre-cluster-role.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    name: sre
+  name: sre
+rules:
+  - apiGroups:
+    - ''
+    resources:
+    - pods
+    verbs:
+    - delete
+
+  - apiGroups:
+    - ''
+    resources:
+    - pods/portforward
+    verbs:
+    - create
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: sre
+  name: sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sre
+subjects:
+- kind: Group
+  name: sre
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: sre-view
+  name: sre-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: Group
+  name: sre
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/gsp-cluster/iam.tf
+++ b/modules/gsp-cluster/iam.tf
@@ -25,6 +25,37 @@ resource "aws_iam_role" "dev" {
   assume_role_policy = "${data.aws_iam_policy_document.grant-iam-dev.json}"
 }
 
+resource "aws_iam_role" "sre" {
+  name = "${var.cluster_name}-sre"
+
+  assume_role_policy = "${data.aws_iam_policy_document.grant-iam-sre-policy.json}"
+}
+
+data "aws_iam_policy_document" "grant-iam-sre-policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals = {
+      type = "AWS"
+
+      identifiers = "${var.sre_user_arns}"
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["${var.gds_external_cidrs}"]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "grant-iam-dev" {
   statement {
     effect  = "Allow"

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -24,6 +24,7 @@ module "bootkube-assets" {
   etcd_client_private_key_pem = "${module.etcd-cluster.client_private_key_pem}"
   etcd_client_cert_pem        = "${module.etcd-cluster.client_cert_pem}"
   admin_role_arns             = ["${var.admin_role_arns}"]
+  sre_role_arns               = ["${aws_iam_role.sre.arn}"]
   dev_role_arns               = ["${aws_iam_role.dev.arn}"]
 }
 
@@ -249,4 +250,9 @@ module "ci-system" {
   cluster_name           = "${var.cluster_name}"
   dns_zone               = "${var.dns_zone}"
   harbor_role_asumer_arn = "${aws_iam_role.kiam_server_role.arn}"
+}
+
+resource "local_file" "role" {
+  filename = "addons/${var.cluster_name}/sre-cluster-role.yaml"
+  content  = "${file("${path.module}/data/sre-cluster-role.yaml")}"
 }

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -24,6 +24,12 @@ variable "dev_user_arns" {
   default     = []
 }
 
+variable "sre_user_arns" {
+  description = "A list of user ARNs that will be mapped to the cluster sre role"
+  type        = "list"
+  default     = []
+}
+
 variable "host_cidr" {
   description = "CIDR IPv4 range to assign to EC2 nodes"
   type        = "string"


### PR DESCRIPTION
This role gives read-only access to most things (via the built-in
Kubernetes `view` role) but does not grant access to Secrets[1].

We extend the `view` role with some additional non-read actions that are
useful for day-to-day SRE-ing.

We will almost certainly have to add more non-read actions as we
discover more things that SREs do regularly.

[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

Co-authored-by Sam Crang <sam.crang@digital.cabinet-office.gov.uk>
Co-authored-by David Pye <david.pye@digital.cabinet-office.gov.uk>