### PR TITLE
Allow the `admin` role to assume the `sre` role

### DIFF
--- a/modules/gsp-cluster/iam.tf
+++ b/modules/gsp-cluster/iam.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "grant-iam-sre-policy" {
     principals = {
       type = "AWS"
 
-      identifiers = "${var.sre_user_arns}"
+      identifiers = ["${concat(var.admin_role_arns, var.sre_user_arns)}"]
     }
 
     condition {


### PR DESCRIPTION
This allows admins to assume a role with _less_ access if they choose.

This also means that our Principal will always be populated with
something. Without this change if a cluster doesn't specify any
`sre_user_arns` a `terraform apply` will fail because of a malformed
policy document.

Soz m8s