### PR TITLE
Commit verification for flux-release module

### DIFF
--- a/modules/flux-release/data/helm-release.yaml
+++ b/modules/flux-release/data/helm-release.yaml
@@ -9,6 +9,7 @@ spec:
     git: "${chart_git}"
     ref: "${chart_ref}"
     path: "${chart_path}"
+    verificationKeys: ${verification_keys}
   valueFileSecrets: ${valueFileSecrets}
   values:
     cluster:

--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -27,6 +27,7 @@ data "template_file" "helm-release" {
     cluster_domain   = "${var.cluster_domain}"
     values           = "${var.values}"
     valueFileSecrets = "[${join(",",formatlist("{\"name\":\"%s\"}", var.valueFileSecrets))}]"
+    verification_keys = "[${join(",",formatlist("%#v", var.verification_keys))}]"
   }
 }
 

--- a/modules/flux-release/variables.tf
+++ b/modules/flux-release/variables.tf
@@ -48,6 +48,12 @@ variable "valueFileSecrets" {
   default     = []
 }
 
+variable "verification_keys" {
+  description = "List of public GPG keys to verify commits against"
+  type        = "list"
+  default     = []
+}
+
 variable "cluster_name" {
   description = "name of this cluster/environment (accessible as .Values.cluster.name in charts)"
   type        = "string"

--- a/modules/gsp-cluster/data/flux.yaml
+++ b/modules/gsp-cluster/data/flux.yaml
@@ -169,7 +169,7 @@ spec:
         # There are no ":latest" images for helm-operator. Find the most recent
         # release or image version at https://quay.io/weaveworks/helm-operator
         # and replace the tag here.
-        image: govsvc/aws-flux-helm-operator:0.0.1551810282
+        image: govsvc/helm-operator:gds-master-b7e03cb3
         imagePullPolicy: IfNotPresent
         args:
         - --charts-sync-interval=1m


### PR DESCRIPTION
## What

We implemented verification of commit signatures against a list of
known public keys in the flux helm operator.

These changes are unlikely to make it upstream in the short term so we
are building and using images from our own fork[<sup>1</sup>][1]

---

[1]: https://github.com/alphagov/gsp-flux
<sup>1</sup> https://github.com/alphagov/gsp-flux
