### PR TITLE
Add count for SSH key generation

### DIFF
--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -54,23 +54,26 @@ resource "local_file" "values" {
 }
 
 resource "tls_private_key" "github_deployment_key" {
+  count     = "${var.enabled == 0 ? 0 : 1}"
   algorithm = "RSA"
   rsa_bits  = "4096"
 }
 
 resource "local_file" "ci-secrets" {
-  filename = "addons/${var.cluster_name}/${var.namespace}-deploy-keys.yaml"
+  count    = "${var.enabled == 0 ? 0 : 1}"
+  filename = "${var.addons_dir}/${var.cluster_name}/${var.namespace}-deploy-keys.yaml"
   content  = "${data.template_file.ci-secrets.rendered}"
 }
 
 data "template_file" "ci-secrets" {
+  count    = "${var.enabled == 0 ? 0 : 1}"
   template = "${file("${path.module}/data/ci-deploy-keys.yaml")}"
 
   vars = {
     ci_namespace = "ci-system-main" # The namespace for the secrets to be read by concourse. Should be `ci-system-[TEAM_NAME]`.
     namespace    = "${var.namespace}" # The namespace of the actual team's release deployment.
-    private_key  = "${base64encode(tls_private_key.github_deployment_key.private_key_pem)}"
-    public_key   = "${tls_private_key.github_deployment_key.public_key_openssh}"
+    private_key  = "${base64encode(element(concat(tls_private_key.github_deployment_key.*.private_key_pem, list("")), count.index))}"
+    public_key   = "${element(concat(tls_private_key.github_deployment_key.*.public_key_openssh, list("")), count.index)}"
     secret_name  = "${var.namespace}"
   }
 }


### PR DESCRIPTION
We're using flux system everywhere wheather or not the release is
enabled.

This causes issues when for instance `ci-system` is disabled in one of
the clusters and still generates the key that it's confused what to do
with it.

It's a technical debt and should go away in the future.