### PR TITLE
Set cluster name/domain as global helm vars

### DIFF
--- a/modules/flux-release/data/helm-release.yaml
+++ b/modules/flux-release/data/helm-release.yaml
@@ -15,4 +15,8 @@ spec:
     cluster:
       name: ${cluster_name}
       domain: ${cluster_domain}
+    global:
+      cluster:
+        name: ${cluster_name}
+        domain: ${cluster_domain}
 ${values}


### PR DESCRIPTION
We pass in cluster.name and cluster.domain as useful vars for use in
writing helm charts that need to know the base domain pointing at the
cluster.

To make these more useful for nested charts (that cannot read the
top-level values) we want to pass these in as helm global values[1]

[1] https://github.com/helm/helm/blob/master/docs/chart_template_guide/subcharts_and_globals.md#global-chart-values