### PR TITLE
add external prometheus labels to montioring-sys

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -148,6 +148,8 @@ module "monitoring-system" {
         prometheusSpec:
           externalLabels:
             clustername: "${var.cluster_name}.${var.dns_zone}"
+            product: "${var.account_name}"
+            deployment: gsp
 EOF
 }
 

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -1,3 +1,9 @@
+variable "account_name" {
+  type        = "string"
+  default     = "gds"
+  description = "descriptive label of account, programme department who owns this cluster"
+}
+
 variable "cluster_name" {
   type = "string"
 }


### PR DESCRIPTION
Pass through labels for prometheus to add to all alerts before sending
on to alertmanager so they can be routed correctly

we map "product" label to the account_name (ie Verify)

we map "deployment" labal (which is used kind of like an environment
type label) to "gsp"
