### PR TITLE
Expose Concourse to the world

### DIFF
--- a/modules/gsp-ci/data/web-configmap.yaml
+++ b/modules/gsp-ci/data/web-configmap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${release_name}-web-configuration"
+  namespace: "${namespace}"
+data:
+  config.yaml: |
+    roles:
+    - name: viewer
+      github:
+        teams: ${teams}

--- a/modules/gsp-ci/main.tf
+++ b/modules/gsp-ci/main.tf
@@ -25,11 +25,19 @@ module "ci-system" {
 
   values = <<EOF
     concourse:
+      secrets:
+        localUsers: "pipeline-operator:${random_string.concourse_password.result}"
       concourse:
         web:
+          auth:
+            mainTeam:
+              localUser: "pipeline-operator"
           kubernetes:
             namespacePrefix: "${module.ci-system.release-name}-"
             createTeamNamespaces: false
+    pipelineOperator:
+      concourseUsername: "pipeline-operator"
+      concoursePassword: "${random_string.concourse_password.result}"
     harbor:
       harborAdminPassword: "${random_string.harbor_password.result}"
       secretKey: "${random_string.harbor_secret_key.result}"

--- a/modules/gsp-ci/main.tf
+++ b/modules/gsp-ci/main.tf
@@ -66,6 +66,7 @@ module "ci-system" {
           kubernetes:
             namespacePrefix: "${module.ci-system.release-name}-"
             createTeamNamespaces: false
+            teams: ["${join(",", concat(list("main"), var.concourse_teams))}"]
     pipelineOperator:
       concourseUsername: "pipeline-operator"
       concoursePassword: "${random_string.concourse_password.result}"

--- a/modules/gsp-ci/main.tf
+++ b/modules/gsp-ci/main.tf
@@ -55,8 +55,19 @@ module "ci-system" {
         additionalVolumeMounts:
         - name: "${module.ci-system.release-name}-web-configuration"
           mountPath: /web-configuration
+        ingress:
+          enabled: true
+          annotations:
+            kubernetes.io/tls-acme: "true"
+          hosts:
+          - "ci.${var.cluster_name}.${var.dns_zone}"
+          tls:
+          - secretName: concourse-web-tls
+            hosts:
+            - "ci.${var.cluster_name}.${var.dns_zone}"
       concourse:
         web:
+          externalUrl: "https://ci.${var.cluster_name}.${var.dns_zone}"
           auth:
             github:
               enabled: true

--- a/modules/gsp-ci/secrets.tf
+++ b/modules/gsp-ci/secrets.tf
@@ -1,3 +1,7 @@
+resource "random_string" "concourse_password" {
+  length = 64
+}
+
 resource "random_string" "notary_passphrase_root" {
   length = 64
 }

--- a/modules/gsp-ci/variables.tf
+++ b/modules/gsp-ci/variables.tf
@@ -13,6 +13,12 @@ variable "dns_zone" {
 variable "harbor_role_asumer_arn" {
   type = "string"
 }
+
+variable "concourse_teams" {
+  default     = []
+  description = "the list of teams to be created in concourse"
+}
+
 variable "github_teams" {
   default     = ["alphagov:re-gsp"]
   description = "the list of github teams allowed to be authenticated into concourse"

--- a/modules/gsp-ci/variables.tf
+++ b/modules/gsp-ci/variables.tf
@@ -13,3 +13,22 @@ variable "dns_zone" {
 variable "harbor_role_asumer_arn" {
   type = "string"
 }
+variable "github_teams" {
+  default     = ["alphagov:re-gsp"]
+  description = "the list of github teams allowed to be authenticated into concourse"
+}
+
+variable "github_client_id" {
+  default     = ""
+  description = "the github application client_id ID to allow oauth"
+}
+
+variable "github_client_secret" {
+  default     = ""
+  description = "the github application client_secret ID to allow oauth"
+}
+
+variable "github_ca_cert" {
+  default     = ""
+  description = "the github application ca_cert ID to allow oauth"
+}

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -229,6 +229,11 @@ module "ci-system" {
   cluster_name           = "${var.cluster_name}"
   dns_zone               = "${var.dns_zone}"
   harbor_role_asumer_arn = "${aws_iam_role.kiam_server_role.arn}"
+
+  github_teams         = "${var.github_teams}"
+  github_client_id     = "${var.github_client_id}"
+  github_client_secret = "${var.github_client_secret}"
+  github_ca_cert       = "${var.github_ca_cert}"
 }
 
 resource "local_file" "role" {

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -234,6 +234,7 @@ module "ci-system" {
   github_client_id     = "${var.github_client_id}"
   github_client_secret = "${var.github_client_secret}"
   github_ca_cert       = "${var.github_ca_cert}"
+  concourse_teams      = "${var.concourse_teams}"
 }
 
 resource "local_file" "role" {

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -164,3 +164,8 @@ variable "github_ca_cert" {
   default     = ""
   description = "the github application ca_cert ID to allow oauth"
 }
+
+variable "concourse_teams" {
+  default     = []
+  description = "the list of teams to be created in concourse"
+}

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -144,3 +144,23 @@ variable "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
   type        = "string"
 }
+
+variable "github_teams" {
+  default     = ["alphagov:re-gsp"]
+  description = "the list of github teams allowed to be authenticated into concourse"
+}
+
+variable "github_client_id" {
+  default     = ""
+  description = "the github application client_id ID to allow oauth"
+}
+
+variable "github_client_secret" {
+  default     = ""
+  description = "the github application client_secret ID to allow oauth"
+}
+
+variable "github_ca_cert" {
+  default     = ""
+  description = "the github application ca_cert ID to allow oauth"
+}


### PR DESCRIPTION
## What

We'd like to allow people to view concourse on their laptops and
dashboard screens without the need of using `kubectl port-forward`
therefore we need to make sure we're not just handing username and
password left and right.

After hardening the login credentials, we're in a better position to
expose concourse to the world.

Managing users is hard and we'd like to put that burden on a third party
oauth provider, which happens to be GitHub.

## How to review

- Code review & Sanity check
- Deploy CI system to a cluster with some GitHub credentials provided