### PR TITLE
Define owner role for pipeline-operator

### DIFF
--- a/modules/gsp-ci/data/web-configmap.yaml
+++ b/modules/gsp-ci/data/web-configmap.yaml
@@ -6,7 +6,12 @@ metadata:
   namespace: "${namespace}"
 data:
   config.yaml: |
+    # It is difficult to find, therefore:
+    # https://concourse-ci.org/managing-teams.html#setting-roles
     roles:
+    - name: owner
+      local:
+        users: ["pipeline-operator"]
     - name: viewer
       github:
         teams: ${teams}


### PR DESCRIPTION
## What

We've been relying on backwards compatibility, which is sadly deprecated
in favour of this roles file. The owner/admin user is no longer assigned
to any team automatically, meaning we get a nice error message when we
attempt to use API with this auth.

It is difficult to find this page, so linking it up:

https://concourse-ci.org/managing-teams.html#setting-roles