### PR TITLE
Add `namespace` label to namespaces

### DIFF
--- a/modules/flux-release/data/namespace.yaml
+++ b/modules/flux-release/data/namespace.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ${namespace}
+  labels:
+    namespace: ${namespace}
   annotations:
     iam.amazonaws.com/permitted: "${permitted_roles_regex}"
 ${extra_namespace_configuration}


### PR DESCRIPTION
If we want to be able to use `namespaceSelector`s (for example on
`NetworkPolicies`) then we need to be able to use `matchLabels` which
requires a label on the `Namespace`.