### PR TITLE
Do not specify `labels` twice

### DIFF
--- a/modules/flux-release/data/namespace.yaml
+++ b/modules/flux-release/data/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   name: ${namespace}
   labels:
     namespace: ${namespace}
+${extra_namespace_labels}
   annotations:
     iam.amazonaws.com/permitted: "${permitted_roles_regex}"
-${extra_namespace_configuration}

--- a/modules/flux-release/main.tf
+++ b/modules/flux-release/main.tf
@@ -4,7 +4,7 @@ data "template_file" "namespace" {
   vars {
     permitted_roles_regex         = "${var.permitted_roles_regex}"
     namespace                     = "${var.namespace}"
-    extra_namespace_configuration = "${var.extra_namespace_configuration}"
+    extra_namespace_labels        = "${var.extra_namespace_labels}"
   }
 }
 

--- a/modules/flux-release/variables.tf
+++ b/modules/flux-release/variables.tf
@@ -69,7 +69,7 @@ variable "permitted_roles_regex" {
   default = ""
 }
 
-variable "extra_namespace_configuration" {
+variable "extra_namespace_labels" {
   type    = "string"
   default = ""
 }

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -110,8 +110,7 @@ module "ingress-system" {
   cluster_domain = "${var.cluster_name}.${var.dns_zone}"
   addons_dir     = "addons/${var.cluster_name}"
 
-  extra_namespace_configuration = <<EOF
-  labels:
+  extra_namespace_labels = <<EOF
     certmanager.k8s.io/disable-validation: "true"
 EOF
 


### PR DESCRIPTION
With namespaces that we had specified `extra_namespace_configuration`
and that `namespace_configuration` included `labels` we would overwrite
the ones defined previously that added a label with the name of the
namespace.

Fortunately the `extra_namespace_configuration` was only ever used for
setting `labels` so we can easily change it.