### PR TITLE
Allow our SREs access to CloudWatch

### DIFF
--- a/modules/gsp-cluster/iam.tf
+++ b/modules/gsp-cluster/iam.tf
@@ -34,7 +34,17 @@ resource "aws_iam_role" "sre" {
 data "aws_iam_policy_document" "grant-iam-sre-policy" {
   statement {
     effect  = "Allow"
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "autoscaling:Describe*",
+      "cloudwatch:Describe*",
+      "cloudwatch:Get*",
+      "cloudwatch:List*",
+      "logs:Get*",
+      "logs:Describe*",
+      "sns:Get*",
+      "sns:List*"
+    ]
 
     principals = {
       type = "AWS"


### PR DESCRIPTION
## What

Sadly, there is no strict restriction to only allow CloudWatch access,
but we will need to have read only access to some random bits in the
system. [AWS docs][1]

[1]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-identity-based-access-control-cw.html#read-only-access-example-cw

## How to review

- Sanity check