### PR TITLE
use groups to make destroy less appealing

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -343,6 +343,7 @@ jobs:
 - name: destroy
   serial: true
   serial_groups: [cluster-modification]
+  disable_manual_trigger: ((disable-destroy))
   plan:
   - get: config
   - get: platform

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -1,3 +1,10 @@
+groups:
+- name: deploy
+  jobs:
+  - deploy
+- name: destroy
+  jobs:
+  - destroy
 
 terraform_source: &terraform_source
   env_name: ((account-name))

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -14,3 +14,4 @@ config-repository: "https://github.com/alphagov/gsp-terraform-ignition.git"
 config-version: "master"
 config-path: "pipelines/examples"
 trusted-developer-keys: []
+disable-destroy: false


### PR DESCRIPTION
we have a "real" environment now, and that destroy job is real tempting

this moves the job to another group reduce change of an accident... we
may want to completely remove this job from persistant clusters