### PR TITLE
grant sre role read-only permisisons to istio/rbac/nodes

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -5,18 +5,62 @@ metadata:
     name: sre
   name: sre
 rules:
-  - apiGroups:
-    - ''
-    resources:
-    - pods
+  - apiGroups: [""]
+    resources: ["pods"]
     verbs:
     - delete
-  - apiGroups:
-    - ''
-    resources:
-    - pods/portforward
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
     verbs:
     - create
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroup: ["rbac.authorization.k8s.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroup: ["apiextensions.k8s.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups: ["config.istio.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups: ["networking.istio.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups: ["authentication.istio.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups: ["rbac.istio.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups: ["monitoring.kiali.io"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
As an sre I want to be able to debug the cluster configuration in detail, including rbac roles and istio network configuration.

This grants `get`, `list` and `watch` permissions to prettymuch all resources in istio and also to nodes and rbac.