### PR TITLE
parameterise setting the node instance types/count

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -27,6 +27,10 @@ terraform_source: &terraform_source
     splunk_hec_token: ((splunk-hec-token))
     splunk_hec_url: ((splunk-hec-url))
     eks_version: ((eks-version))
+    worker_instance_type: ((worker-instance-type))
+    worker_count: ((worker-count))
+    ci_worker_instance_type: ((ci-worker-instance-type))
+    ci_worker_count: ((ci-worker-count))
 
 task_image_resource: &task_image_resource
   type: docker-image

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -16,3 +16,7 @@ config-version: "master"
 config-path: "pipelines/examples"
 trusted-developer-keys: []
 disable-destroy: false
+worker_instance_type: t3.medium
+worker_count: 3
+ci_worker_instance_type: t3.micro
+ci_worker_count: 3


### PR DESCRIPTION
we need to be able to configure the cluster sizing and node sizing from
the pipeline. this exposes the terraform variables for
ci_worker_instance_type, ci_worker_count, worker_instance_type and
worker_count from the concourse input variables.