### PR TITLE
Restrict node groups to private IP subnets.

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -1,7 +1,8 @@
 module "k8s-cluster" {
   source                  = "../k8s-cluster"
   vpc_id                  = "${var.vpc_id}"
-  subnet_ids              = ["${concat(var.private_subnet_ids, var.public_subnet_ids)}"]
+  private_subnet_ids      = ["${var.private_subnet_ids}"]
+  public_subnet_ids       = ["${var.public_subnet_ids}"]
   cluster_name            = "${var.cluster_name}"
   worker_count            = "${var.worker_count}"
   worker_instance_type    = "${var.worker_instance_type}"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -9,7 +9,7 @@ resource "aws_eks_cluster" "eks-cluster" {
 
   vpc_config {
     security_group_ids = ["${aws_security_group.controller.id}"]
-    subnet_ids         = ["${var.subnet_ids}"]
+    subnet_ids         = ["${concat(var.private_subnet_ids, var.public_subnet_ids)}"]
   }
 
   enabled_cluster_log_types = [
@@ -44,7 +44,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker\""
     VpcId                               = "${var.vpc_id}"
-    Subnets                             = "${join(",", var.subnet_ids)}"
+    Subnets                             = "${join(",", var.private_subnet_ids)}"
   }
 
   depends_on = ["aws_eks_cluster.eks-cluster"]
@@ -67,7 +67,7 @@ resource "aws_cloudformation_stack" "kiam-server-nodes" {
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/cluster-management --register-with-taints=node-role.kubernetes.io/cluster-management=:NoSchedule\""
     VpcId                               = "${var.vpc_id}"
-    Subnets                             = "${join(",", var.subnet_ids)}"
+    Subnets                             = "${join(",", var.private_subnet_ids)}"
   }
 
   depends_on = ["aws_eks_cluster.eks-cluster"]
@@ -90,7 +90,7 @@ resource "aws_cloudformation_stack" "ci-nodes" {
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/ci --register-with-taints=node-role.kubernetes.io/ci=:NoSchedule\""
     VpcId                               = "${var.vpc_id}"
-    Subnets                             = "${join(",", var.subnet_ids)}"
+    Subnets                             = "${join(",", var.private_subnet_ids)}"
   }
 
   depends_on = ["aws_eks_cluster.eks-cluster"]

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -2,7 +2,11 @@ variable "vpc_id" {
   type = "string"
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
+  type = "list"
+}
+
+variable "private_subnet_ids" {
   type = "list"
 }
 


### PR DESCRIPTION
Some pods were being scheduled onto nodes in the public ranges preventing
them from accessing certain AWS resources that were protected by security
groups (e.g. CloudHSM). No workers should be instantiated in the public
subnets.