### PR TITLE
allows setting cluster-domain from cluster config

### DIFF
--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -14,6 +14,7 @@ fly -t cd-gsp sync
 fly -t cd-gsp set-pipeline -p "${CLUSTER_NAME}" --config pipelines/deployer/deployer.yaml \
 	--load-vars-from pipelines/examples/clusters/sandbox.yaml \
 	--var cluster-name=${CLUSTER_NAME} \
+	--var cluster-domain=london.${CLUSTER_NAME}.govsvc.uk \
 	--var platform-version=${PLATFORM_BRANCH} \
 	--var config-version=${PLATFORM_BRANCH} \
 	--check-creds

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -16,7 +16,7 @@ terraform_source: &terraform_source
     account_id: ((account-id))
     account_name: ((account-name))
     cluster_name: ((cluster-name))
-    cluster_domain: ((cluster-name)).((account-name)).govsvc.uk
+    cluster_domain: ((cluster-domain))
     cluster_number: ((cluster-number))
     aws_account_role_arn: ((account-role-arn))
     promotion_signing_key: ((ci-system-gpg-private))


### PR DESCRIPTION
with cluster names being the same as account names we get weird
generated cluster-domains like portfolio.portfolio.govsvc.uk.

to avoid this while not being too prescriptive about exactly what the
domains are we are allowing setting the cluster domain manually from the
deployer pipeline.

Related: https://github.com/alphagov/gsp-teams/pull/147