### PR TITLE
fix extranous quotes around concourse password

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -35,7 +35,8 @@ notary:
 concourseMainTeamGithubTeams: ${concourse_main_team_github_teams}
 concourse:
   secrets:
-    localUsers: pipeline-operator:${concourse_admin_password}
+    localUsers: >-
+      pipeline-operator:${concourse_admin_password}
     githubClientId: ${github_client_id}
     githubClientSecret: ${github_client_secret}
     githubCaCert: ${github_ca_cert}
@@ -63,7 +64,8 @@ concourse:
 
 pipelineOperator:
   concourseUsername: pipeline-operator
-  concoursePassword: ${concourse_admin_password}
+  concoursePassword: >-
+    ${concourse_admin_password}
 
 harbor:
   harborAdminPassword: ${harbor_admin_password}

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -11,7 +11,7 @@ data "template_file" "values" {
     sre_role_arns                       = "${jsonencode(var.sre_role_arns)}"
     sre_user_arns                       = "${jsonencode(var.sre_user_arns)}"
     bootstrap_role_arns                 = "${jsonencode(module.k8s-cluster.bootstrap_role_arns)}"
-    concourse_admin_password            = "${jsonencode(random_string.concourse_password.result)}"
+    concourse_admin_password            = "${random_string.concourse_password.result}"
     concourse_teams                     = "${jsonencode(concat(list("main"), var.concourse_teams))}"
     concourse_main_team_github_teams    = "${jsonencode(var.concourse_main_team_github_teams)}"
     concourse_worker_count              = "${var.ci_worker_count}"


### PR DESCRIPTION
concourse password was being "quoted" in an incorrect way causing the
pipeline operator to be passed a different password to what concourse
web was using