### PR TITLE
generate concourse teams for each namespace

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -1,4 +1,6 @@
+{{- $clusterName := .Values.global.cluster.name }}
 {{- range .Values.namespaces }}
+{{- $ns := . }}
 {{- range .resources }}
 ---
 {{ tpl (toYaml .) $ }}
@@ -30,4 +32,31 @@ roleRef:
   kind: Role
   name: pod-reader
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Team
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ trimPrefix $clusterName .name }}
+spec:
+  roles:
+  - name: owner
+    local:
+      users: ["pipeline-operator"]
+  - name: pipeline-operator
+    local:
+      users:
+      {{- range $.Values.users }}
+        {{- $user := . }}
+        {{- range .roles }}
+          {{- if and (hasPrefix $clusterName .) (hasSuffix "-sre" .) }}
+        - {{ $user.github }}
+          {{- else if and (hasPrefix $clusterName .) (hasSuffix "-admin" .) }}
+        - {{ $user.github }}
+          {{- else if and (hasPrefix $ns.name .) (hasSuffix "-dev" .) }}
+        - {{ $user.github }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -24,30 +24,42 @@ rm -rf output || echo 'ok'
 mkdir -p output
 
 cat << 'EOF' > output/values.yaml
+global:
+  cluster:
+    domain: fake.com
+    name: sandbox
 namespaces:
 - name: sandbox-canary
+  resources: [{"apiVersion":"v1","kind":"Secret","type":"Opaque","metadata":{"name":"ci-deploy-key"},"data":{"private_key":"RklYTUUK"}},{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"ci-deploy-key"},"data":{"public_key":"RklYTUUK"}},{"apiVersion":"flux.weave.works/v1beta1","kind":"HelmRelease","metadata":{"name":"canary"},"spec":{"releaseName":"canary","chart":{"git":"{{ .Values.global.canary.repository }}","ref":"master","path":"charts/gsp-canary","verificationKeys":"{{ .Values.global.canary.verificationKeys }}"},"values":{"annotations":{"iam.amazonaws.com/role":"{{ .Values.global.roles.canary }}"},"updater":{"helmChartRepoUrl":"{{ .Values.global.canary.repository }}"}}}}]
+- name: jefferson-canary
   resources: [{"apiVersion":"v1","kind":"Secret","type":"Opaque","metadata":{"name":"ci-deploy-key"},"data":{"private_key":"RklYTUUK"}},{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"ci-deploy-key"},"data":{"public_key":"RklYTUUK"}},{"apiVersion":"flux.weave.works/v1beta1","kind":"HelmRelease","metadata":{"name":"canary"},"spec":{"releaseName":"canary","chart":{"git":"{{ .Values.global.canary.repository }}","ref":"master","path":"charts/gsp-canary","verificationKeys":"{{ .Values.global.canary.verificationKeys }}"},"values":{"annotations":{"iam.amazonaws.com/role":"{{ .Values.global.roles.canary }}"},"updater":{"helmChartRepoUrl":"{{ .Values.global.canary.repository }}"}}}}]
 users:
 - name: chris.farmiloe
   email: chris.farmiloe@digital.cabinet-office.gov.uk
-  ARN: arn:aws:iam::622626885786:user/chris.farmiloe@digital.cabinet-office.gov.uk
+  ARN: arn:aws:iam::000000072:user/chris.farmiloe@digital.cabinet-office.gov.uk
   roles:
   - sandbox-admin
-  - sandbox-sre
-  - sandbox-canary-dev
-  roleARN: arn:aws:iam::011571571136:role/farms-user-chris.farmiloe
+  roleARN: arn:aws:iam::000000072:role/chris.farmiloe
+  github: "chrisfarms"
 - name: sam.crang
   email: sam.crang@digital.cabinet-office.gov.uk
-  ARN: arn:aws:iam::622626885786:user/sam.crang@digital.cabinet-office.gov.uk
+  ARN: arn:aws:iam::000000072:user/sam.crang@digital.cabinet-office.gov.uk
   roles:
-  - sandbox-canary-dev
-  roleARN: arn:aws:iam::011571571136:role/farms-user-sam.crang
+  - sandbox-sre
+  roleARN: arn:aws:iam::000000072:role/sam.crang
+  github: "samcrang"
+- name: jeff.jefferson
+  email: jeff.jefferson@digital.cabinet-office.gov.uk
+  ARN: arn:aws:iam::000000072:user/jeff.jefferson@digital.cabinet-office.gov.uk
+  roles:
+  - jefferson-canary-dev
+  roleARN: arn:aws:iam::000000072:role/jeff.jefferson
+  github: "jefferz83"
 EOF
 
 helm template \
 	--output-dir ./output \
 	--namespace fake-system \
-	--values output/values.yaml \
 	--values <(\
 		cat modules/gsp-cluster/data/values.yaml \
 		| sed 's/${admin_role_arns}/[]/' \
@@ -57,5 +69,6 @@ helm template \
 		| sed 's/${bootstrap_role_arns}/[]/' \
 		| sed 's/${concourse_teams}/["org:team"]/' \
 	) \
+	--values output/values.yaml \
 	"charts/gsp-cluster"
 


### PR DESCRIPTION
## What

each namespace will get its own concourse team, and access will
be granted to the github users who have the appropriate roles assigned

example:

a namespace called "sandbox-myapp" in the "sandbox" cluster would get a
concourse team called "myapp" created.

user with role "sandbox-sre" or "sandbox-myapp-dev" will get
pipeline-operator role assigned for the concourse team.

Note: the hack/lint script is just a hacky thing for rendering out the template so you can look at it, not used for anything serious

## Why

So that we can use the same user roles/namespacing to segregate concourse usage