### PR TITLE
Local Concourse and Harbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The platform is for teams working in the [Government Digital Service](https://ww
 
 ## Running locally
 
-It is possible to run a GSP cluster locally using [kind](https://kind.sigs.k8s.io/). You will probably want to give your Docker daemon more RAM than the default (anecdotally 8GB works).
+It is possible to run a GSP cluster locally using [Minikube](https://kubernetes.io/docs/setup/minikube/).
 
 To create a cluster run:
 
@@ -41,11 +41,15 @@ To create a cluster run:
 ./scripts/gsp-local.sh create
 ```
 
-You can then play with some of the services:
+After more than 5 minutes, but less than 10 the script should terminate and a cluster will be available:
 
 ```
-export KUBECONFIG="$(kind get kubeconfig-path --name="gsp-local")"
+kubectl cluster-info
+```
 
+You can then connect to some of the GSP-provided services:
+
+```
 # Workaround the fact Istio doesn't let you have specify ports on
 # hosts with VirtualServices so we have to run it on a priviledged
 # port:

--- a/docs/gds-supported-platform/getting-started.md
+++ b/docs/gds-supported-platform/getting-started.md
@@ -8,22 +8,19 @@ This process is resource-intensive and you must set the resource amount used by 
 
 ## Build a local GSP cluster
 
-1. Install and configure [Golang](https://golang.org/).
-
 1. Install [homebrew](https://brew.sh/):
 
-1. Run the following in the command line to install `kubectl` and `helm`:
+1. Install dependencies:
 
     ```
+    brew cask install minikube
     brew install kubernetes-cli
     brew install kubernetes-helm
+    brew install hyperkit
+    brew install docker-machine-driver-hyperkit
     ```
 
-1. Install [`kind`](https://kind.sigs.k8s.io/):
-
-    ```
-    GO111MODULE="on" go get -u sigs.k8s.io/kind@v0.3.0
-    ```
+    After installing `docker-machine-driver-hyperkit` follow instructions on how to grant driver superuser privileges to the hypervisor.
 
 1. Clone the GSP repo:
 
@@ -38,12 +35,6 @@ This process is resource-intensive and you must set the resource amount used by 
     ```
 
     If this script is still running after 15 minutes, contact the GSP team using the [re-GSP Slack channel](https://gds.slack.com/messages/CDA7YSP0D).
-
-1. Configure `kubectl` to use the local GSP cluster:
-
-    ```
-    export KUBECONFIG="$(kind get kubeconfig-path --name="gsp-local")"
-    ```
 
 1. Check that you can access your local GSP cluster using [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/):
 

--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -4,14 +4,14 @@ set -eu
 
 script_dir=$(dirname $0)
 
+function usage() {
+	echo "Usage: ${0} [create|destroy|template]"
+}
+
 if [ $# -lt 1 ]; then
 	usage
 	exit 1
 fi
-
-function usage() {
-	echo "Usage: ${0} [create|destroy|template]"
-}
 
 function log() {
 	echo "☁️  ${1}" 1>&2

--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -93,6 +93,7 @@ minikube start \
 	--disk-size 30g \
 	--vm-driver hyperkit \
 	--kubernetes-version v1.12.0 \
+	--insecure-registry "registry.local.govsandbox.uk:80" \
 	--profile ${cluster_name}
 
 kubectl config set-context --current --namespace gsp-system

--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -43,7 +43,7 @@ cluster_name=gsp-local
 case ${option} in
 	destroy|delete)
 		log "Destroying local GSP..."
-		kind delete cluster --name ${cluster_name}
+		minikube delete --profile ${cluster_name}
 		exit 0
 		;;
 	template)
@@ -87,12 +87,14 @@ function apply() {
 }
 
 log "Creating local GSP..."
+minikube start \
+	--memory 8192 \
+	--cpus 4 \
+	--disk-size 30g \
+	--vm-driver hyperkit \
+	--kubernetes-version v1.12.0 \
+	--profile ${cluster_name}
 
-kind create cluster \
-	--name ${cluster_name} \
-	|| (log "Local GSP cluster already exists." && exit 1)
-
-export KUBECONFIG="$(kind get kubeconfig-path --name="${cluster_name}")"
 kubectl config set-context --current --namespace gsp-system
 
 manifest_dir=$(mktemp -d)
@@ -123,4 +125,3 @@ apply "${script_dir}/hack/expose-grafana.yaml"
 
 kubectl cluster-info
 log "Local GSP ready."
-echo "export KUBECONFIG=\"\$(kind get kubeconfig-path --name=\"${cluster_name}\")\""

--- a/scripts/local-values.yaml
+++ b/scripts/local-values.yaml
@@ -18,6 +18,9 @@ concourse:
     persistence:
       enabled: false
 
+harbor:
+  externalURL: http://registry.local.govsandbox.uk
+
 pipelineOperator:
   image:
     repository: "govsvc/gsp-concourse-pipeline-controller"

--- a/scripts/local-values.yaml
+++ b/scripts/local-values.yaml
@@ -19,6 +19,13 @@ concourse:
       enabled: false
 
 harbor:
+  expose:
+    type: ingress
+    tls:
+      enabled: false
+    ingress:
+      hosts:
+        core: registry.local.govsandbox.uk
   externalURL: http://registry.local.govsandbox.uk
 
 pipelineOperator:


### PR DESCRIPTION
You should be able build and push an image with a pipeline that looks something like this:

```
resource_types:
- name: harbor
  type: docker-image
  privileged: true
  source:
    repository: govsvc/gsp-harbor-docker-image-resource
    tag: "0.0.1558617848"

- name: github
  type: docker-image
  privileged: true
  source:
    repository: "govsvc/concourse-github-resource"
    tag: "0.0.1551114195"

harbor_source: &harbor_source
  username: admin
  password: Harbor12345
  insecure_registries: ["registry.local.govsandbox.uk:80"]
  harbor:
    url: http://registry.local.govsandbox.uk
    prevent_vul: "false"
    enable_content_trust: "false"
    enable_notary: "false"
  notary:
    url: http://notary.local.govsandbox.uk
    root_key: ""
    delegate_key:  ""
    passphrase:
      root: ""
      snapshot: ""
      targets: ""
      delegation: ""

resources:
- name: foo-repo
  type: git
  source:
    uri: "https://github.com/alphagov/gsp-docker-images"

- name: foo-image
  type: harbor
  source:
    <<: *harbor_source
    repository: registry.local.govsandbox.uk:80/lol/concourse-terraform-resource

jobs:
- name: build-foo
  plan:
  - get: foo-repo
    trigger: true
  - put: foo-image
    params:
      build: foo-repo
      dockerfile: foo-repo/concourse-terraform-resource/Dockerfile
```

You should be able to run that image with something like:

```
kubectl run -it --image="registry.local.govsandbox.uk:80/lol/concourse-terraform-resource:latest" lol
```