### PR TITLE
add some empty defaults to splunk vars

### DIFF
--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -38,10 +38,12 @@ variable "splunk_enabled" {
 
 variable "splunk_hec_url" {
   type = "string"
+  default = ""
 }
 
 variable "k8s_splunk_hec_token" {
   type = "string"
+  default = ""
 }
 
 variable "k8s_splunk_index" {
@@ -51,6 +53,7 @@ variable "k8s_splunk_index" {
 
 variable "hsm_splunk_hec_token" {
   type = "string"
+  default = ""
 }
 
 variable "hsm_splunk_index" {
@@ -60,6 +63,7 @@ variable "hsm_splunk_index" {
 
 variable "vpc_flow_log_splunk_hec_token" {
   type = "string"
+  default = ""
 }
 
 variable "vpc_flow_log_splunk_index" {


### PR DESCRIPTION

We noticed that some vars are not defined and so are invalid when using fly to push a pipeline for test. We've set defaults of empty strings.

@smford 
@szd55gds 