### PR TITLE
Fix typo in vpc flow logs principal

### DIFF
--- a/modules/gsp-cluster/vpc-flow-logs.tf
+++ b/modules/gsp-cluster/vpc-flow-logs.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "cloudwatch_vpc_flow_log_assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["vpc-flow-log.amazonaws.com"]
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
It should be a plural: vpc-flow-logs.amazonaws.com