### PR TITLE
Reduce permissions granted to all worker nodes.

### DIFF
--- a/modules/gsp-cluster/monitoring-system.tf
+++ b/modules/gsp-cluster/monitoring-system.tf
@@ -49,7 +49,10 @@ resource "aws_iam_policy" "cloudwatch_log_shipping_policy" {
 
 resource "aws_iam_policy_attachment" "cloudwatch_log_shipping_policy" {
   name       = "${var.cluster_name}_cloudwatch_log_shipping_role_policy_attachement"
-  roles      = ["${aws_iam_role.cloudwatch_log_shipping_role.name}"]
+  roles      = [
+    "${aws_iam_role.cloudwatch_log_shipping_role.name}",
+    "${module.k8s-cluster.kiam-server-node-instance-role-name}",
+  ]
   policy_arn = "${aws_iam_policy.cloudwatch_log_shipping_policy.arn}"
 }
 

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -6,6 +6,10 @@ output "kiam-server-node-instance-role-arn" {
   value = "${aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRole"]}"
 }
 
+output "kiam-server-node-instance-role-name" {
+  value = "${replace(data.aws_arn.kiam-server-nodes-role.resource, "role/", "")}"
+}
+
 output "bootstrap_role_arns" {
   value = "${list(aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceRole"], aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRole"], aws_cloudformation_stack.ci-nodes.outputs["NodeInstanceRole"])}"
 }


### PR DESCRIPTION
SSM, it turns out, doesn't require the majority of the permissions
afforded it by the AWS managed policy. So use a stripped down version
that is enough to allow SSH from the AWS Console Session Manager.

Spot tested using Session Manager to SSH to one of each worker group. Also checked that the kiam server was pushing logs to CloudWatch.