### PR TITLE
Increase lambda forwarder timeout

### DIFF
--- a/modules/lambda_splunk_forwarder/lambda.tf
+++ b/modules/lambda_splunk_forwarder/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "lambda_log_forwarder" {
   role             = "${aws_iam_role.lambda_log_forwarder.arn}"
   handler          = "lambda_function.lambda_handler"
   runtime          = "python3.6"
-  timeout          = "10"
+  timeout          = "60"
   memory_size      = "128"
   description      = "A function to forward logs from AWS to a Splunk HEC using a manual zip of https://github.com/alphagov/cyber-cloudwatch-fluentd-to-hec"
 


### PR DESCRIPTION
forwarding lambda is timing out causing missing logs in splunk ...increasing the timeout to 60s to give it a bit more time.