### PR TITLE
Run a subset of the k8s e2e tests with Sonobuoy

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -38,7 +38,7 @@ terraform_source: &terraform_source
 
 task_image_resource: &task_image_resource
   type: docker-image
-  source: {repository: "govsvc/task-toolbox", tag: "1.2.0"}
+  source: {repository: "govsvc/task-toolbox", tag: "1.3.0"}
 
 generate_cluster_values: &generate_cluster_values
   platform: linux
@@ -216,6 +216,69 @@ apply_cluster_chart: &apply_cluster_chart
   - name: namespace-values
   - name: platform
 
+run_conformance_tests: &run_conformance_tests
+  platform: linux
+  image_resource: *task_image_resource
+  params:
+    ACCOUNT_ROLE_ARN: ((account-role-arn))
+    ACCOUNT_NAME: ((account-name))
+    CLUSTER_NAME: ((cluster-name))
+    DEFAULT_NAMESPACE: gsp-system
+    AWS_REGION: eu-west-2
+    AWS_DEFAULT_REGION: eu-west-2
+  run:
+    path: /bin/bash
+    args:
+    - -eu
+    - -c
+    - |
+      echo "assuming aws deployer role..."
+      AWS_CREDS="$(aws-assume-role $ACCOUNT_ROLE_ARN)"
+      eval "${AWS_CREDS}"
+      echo "fetching kubeconfig from aws..."
+      aws eks update-kubeconfig \
+        --name "${CLUSTER_NAME}" \
+        --kubeconfig ./kubeconfig
+      export KUBECONFIG=$(pwd)/kubeconfig
+      echo "setting default namespace to ${DEFAULT_NAMESPACE}"
+      kubectl config set-context $(kubectl config get-contexts -o name) \
+        --namespace "${DEFAULT_NAMESPACE}"
+
+      echo "beginning conformance test..."
+      mkdir -p plugins/e2e/results
+
+      function cleanup() {
+        echo "cleaning up sonobuoy..."
+         sonobuoy delete --wait
+      }
+      trap 'cleanup' INT TERM EXIT
+
+      sonobuoy run \
+        --wait \
+        --sonobuoy-image "gcr.io/heptio-images/sonobuoy:v0.14.2" \
+        --plugin e2e \
+        --e2e-focus "Pods should be submitted and removed" \
+        --kube-conformance-image "govsvc/conformance-amd64:0.0.1559644071" \
+        --plugin-env e2e.ALLOWED_NOT_READY_NODES=$(kubectl get nodes --selector "! node-role.kubernetes.io/worker"  --no-headers=true | wc -l) # only wait for worker nodes
+
+      sleep 10 # wait for results to be written
+      results=$(sonobuoy retrieve)
+      sonobuoy e2e ${results}
+      passed=$(sonobuoy e2e ${results} --show passed | head -n1)
+      failed=$(sonobuoy e2e ${results} --show failed | head -n1)
+
+      if [[ ${passed} == "passed tests: 1" && ${failed} == "failed tests: 0" ]]; then
+        echo "SUCCESS"
+        exit 0
+      fi
+
+      echo "FAIL"
+      exit 1
+  inputs:
+  - name: cluster-values
+  - name: user-values
+  - name: namespace-values
+  - name: platform
 
 drain_cluster_task: &drain_cluster_task
   platform: linux
@@ -443,6 +506,9 @@ jobs:
   - task: apply-cluster-chart
     timeout: 10m
     config: *apply_cluster_chart
+  - task: run-conformance-tests
+    timeout: 15m
+    config: *run_conformance_tests
 - name: destroy
   serial: true
   serial_groups: [cluster-modification]


### PR DESCRIPTION
This requires a [custom version of the k8s acceptance tests](https://github.com/alphagov/kubernetes/tree/allow-node-count) (instructions for building in commit) and an [unreleased version of Sonobuoy](https://github.com/alphagov/gsp-docker-images/pull/16).