### PR TITLE
Add a Brewfile to make installing pre-requisites easier

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,10 @@
+tap "homebrew/core"
+tap "homebrew/cask"
+
+brew "kubernetes-cli"
+brew "kubernetes-helm"
+brew "hyperkit"
+brew "docker-machine-driver-hyperkit"
+
+cask "aws-vault"
+cask "minikube"

--- a/docs/gds-supported-platform/getting-started.md
+++ b/docs/gds-supported-platform/getting-started.md
@@ -8,16 +8,12 @@ This process is resource-intensive and you must set the resource amount used by 
 
 ## Build a local GSP cluster
 
-1. Install [homebrew](https://brew.sh/):
+1. Install [Homebrew](https://brew.sh/)
 
-1. Install dependencies:
+1. Install dependencies from the Brewfile at the root of the repo:
 
     ```
-    brew cask install minikube
-    brew install kubernetes-cli
-    brew install kubernetes-helm
-    brew install hyperkit
-    brew install docker-machine-driver-hyperkit
+    brew bundle
     ```
 
     After installing `docker-machine-driver-hyperkit` follow instructions on how to grant driver superuser privileges to the hypervisor.


### PR DESCRIPTION
- Brewfiles mean that users can run `brew bundle` instead of individual `brew
  install` commands.
- Edit the docs to note that we're now getting dependencies from the Brewfile.

- I also noticed \`aws-vault\` elsewhere, so I've added it.