### PR TITLE
Allow sandbox cluster to have less restrictive deployments

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -348,7 +348,7 @@ resource_types:
 
 resources:
 - name: platform
-  type: github
+  type: ((git-resource-type))
   source:
     uri: ((platform-uri))
     organization: ((platform-organization))
@@ -359,7 +359,7 @@ resources:
     branch: ((platform-version))
     commit_verification_keys: ((trusted-developer-keys))
 - name: config
-  type: github
+  type: ((git-resource-type))
   source:
     uri: ((config-uri))
     organization: ((config-organization))
@@ -370,7 +370,7 @@ resources:
     branch: ((config-version))
     commit_verification_keys: ((trusted-developer-keys))
 - name: users
-  type: github
+  type: ((git-resource-type))
   source:
     uri: ((users-uri))
     organization: ((users-organization))


### PR DESCRIPTION
The `github` resource requires a PR with a minimum number of approvals.
This makes changes to the sandbox cluster (and possibly other places
where we need to iterate quickly) awkward.

This change replaces the `github` resource with the `git` resource in
the sandbox cluster.