### PR TITLE
Move gsp-canary-chart repo to gsp-canary

### DIFF
--- a/modules/gsp-cluster/canary-system.tf
+++ b/modules/gsp-cluster/canary-system.tf
@@ -46,7 +46,7 @@ resource "aws_codecommit_repository" "canary" {
     command = "${path.module}/scripts/initialise_canary_helm_codecommit.sh"
 
     environment {
-      SOURCE_REPO_URL          = "https://github.com/alphagov/gsp-canary-chart"
+      SOURCE_REPO_URL          = "https://github.com/alphagov/gsp-canary"
       CODECOMMIT_REPO_URL      = "${aws_codecommit_repository.canary.clone_url_http}"
       CODECOMMIT_INIT_ROLE_ARN = "${var.codecommit_init_role_arn}"
     }


### PR DESCRIPTION
The GSP has moved repos from gsp-canary-chart to gsp-canary.

Solo: @smford