### PR TITLE
Fix path to values.yaml for the new gsp-canary repo

### DIFF
--- a/modules/gsp-cluster/scripts/initialise_canary_helm_codecommit.sh
+++ b/modules/gsp-cluster/scripts/initialise_canary_helm_codecommit.sh
@@ -46,7 +46,7 @@ fi
 git branch -u source/master
 
 # update the embedded timestamp
-sed -i.bak -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" charts/gsp-canary/values.yaml
-git add charts/gsp-canary/values.yaml
+sed -i.bak -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" gsp-canary/charts/values.yaml
+git add gsp-canary/charts/values.yaml
 git commit -m "Initial timestamp update."
 git push --force destination master


### PR DESCRIPTION
GSP Canary no longer uses codecommit, this is a temporary
fix to re-open the deployment pipelines until use of
codecommit is fully removed.

Solo: @smford