### PR TITLE
Fix typo in pathname of chart

### DIFF
--- a/modules/gsp-cluster/scripts/initialise_canary_helm_codecommit.sh
+++ b/modules/gsp-cluster/scripts/initialise_canary_helm_codecommit.sh
@@ -46,7 +46,7 @@ fi
 git branch -u source/master
 
 # update the embedded timestamp
-sed -i.bak -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" gsp-canary/charts/values.yaml
-git add gsp-canary/charts/values.yaml
+sed -i.bak -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" gsp-canary/chart/values.yaml
+git add gsp-canary/chart/values.yaml
 git commit -m "Initial timestamp update."
 git push --force destination master


### PR DESCRIPTION
Fix typo:
Wrong: gsp-canary/charts/values.yaml
Right: gsp-canary/chart/values.yaml

Solo: @smford