### PR TITLE
set-pipeline: Sorting user keys and passing fly args

### DIFF
--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -23,14 +23,14 @@ approvers="/tmp/deployer-${CLUSTER_NAME}-approvers.yaml"
 echo -n "github-approvers: " > "${approvers}"
 cat ${USER_CONFIGS}/*.yaml \
 	| yq . \
-	| jq -c -s "[.[] | select(.roles[] | select((. == \"${CLUSTER_NAME}-sre\" ) or (. == \"${CLUSTER_NAME}-admin\"))) | .github] | unique" \
+	| jq -c -s "[.[] | select(.roles[] | select((. == \"${CLUSTER_NAME}-sre\" ) or (. == \"${CLUSTER_NAME}-admin\"))) | .github] | unique | sort" \
 	>> "${approvers}"
 
 trusted="/tmp/deployer-${CLUSTER_NAME}-keys.yaml"
 echo -n "trusted-developer-keys: " > "${trusted}"
 cat ${USER_CONFIGS}/*.yaml \
 	| yq . \
-	| jq -c -s '[ .[].pub ]' \
+	| jq -c -s '[ .[].pub ] | sort' \
 	>> "${trusted}"
 
 fly -t cd-gsp sync

--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -42,7 +42,7 @@ fly -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--var "platform-version=${CURRENT_BRANCH}" \
 	--load-vars-from "${approvers}" \
 	--load-vars-from "${trusted}" \
-	--check-creds
+	--check-creds "$@"
 
 fly -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -435,12 +435,12 @@ jobs:
           echo "generating list of pipeline approvers..."
           echo -n "github-approvers: " > approvers.yaml
           yq . users/users/*.yaml \
-            | jq -c -s "[.[] | select(.roles[] | select((. == \"${CLUSTER_NAME}-sre\" ) or (. == \"${CLUSTER_NAME}-admin\"))) | .github] | unique" \
+            | jq -c -s "[.[] | select(.roles[] | select((. == \"${CLUSTER_NAME}-sre\" ) or (. == \"${CLUSTER_NAME}-admin\"))) | .github] | unique | sort" \
             >> approvers.yaml
           echo "generating list of trusted-developer-keys for pipeline changes"
           echo -n "trusted-developer-keys: " > trusted-developer-keys.yaml
           yq . users/users/*.yaml \
-            | jq -c -s '[ .[].pub ]' \
+            | jq -c -s '[ .[].pub ] | sort' \
             >> trusted-developer-keys.yaml
           echo "downloading correct fly version..."
           curl -L --fail "${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=linux" > fly


### PR DESCRIPTION
* fix: sort user names/keys when set-pipelineing or self-updating so you don't get weird diffs when applying
* feature: allow passing in fly args to set-pipeline so that you can add things like `--var disable-update=true` when pinning to different branch