### PR TITLE
Add splunky audit lambda

### DIFF
--- a/modules/gsp-cluster/splunk-system.tf
+++ b/modules/gsp-cluster/splunk-system.tf
@@ -10,6 +10,18 @@ module "k8s_lambda_splunk_forwarder" {
   splunk_index              = "${var.k8s_splunk_index}"
 }
 
+module "eks_lambda_splunk_forwarder" {
+  source                    = "../lambda_splunk_forwarder"
+  enabled                   = "${var.splunk_enabled}"
+  name                      = "pods"
+  cloudwatch_log_group_arn  = "${module.k8s-cluster.eks-log-group-arn}"
+  cloudwatch_log_group_name = "${module.k8s-cluster.eks-log-group-name}"
+  cluster_name              = "${var.cluster_name}"
+  splunk_hec_token          = "${var.k8s_splunk_hec_token}"
+  splunk_hec_url            = "${var.splunk_hec_url}"
+  splunk_index              = "${var.k8s_splunk_index}"
+}
+
 module "vpc_flow_log_lambda_splunk_forwarder" {
   source                    = "../lambda_splunk_forwarder"
   enabled                   = "${var.splunk_enabled}"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -23,7 +23,13 @@ resource "aws_eks_cluster" "eks-cluster" {
   depends_on = [
     "aws_iam_role_policy_attachment.eks-cluster-policy",
     "aws_iam_role_policy_attachment.eks-service-policy",
+    "aws_cloudwatch_log_group.eks",
   ]
+}
+
+resource "aws_cloudwatch_log_group" "eks" {
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = 30
 }
 
 # As per https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -23,7 +23,6 @@ resource "aws_eks_cluster" "eks-cluster" {
   depends_on = [
     "aws_iam_role_policy_attachment.eks-cluster-policy",
     "aws_iam_role_policy_attachment.eks-service-policy",
-    "aws_cloudwatch_log_group.eks",
   ]
 }
 

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -17,3 +17,11 @@ output "bootstrap_role_arns" {
 output "worker_http_target_group_arn" {
   value = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]}"
 }
+
+output "eks-log-group-arn" {
+  value = "${aws_cloudwatch_log_group.eks.arn}"
+}
+
+output "eks-log-group-name" {
+  value = "${aws_cloudwatch_log_group.eks.name}"
+}


### PR DESCRIPTION
## What

* Adds lambda to ship control-plane logs to splunk.
* Creates the eks log group ahead of time

eks automatically creates a log group for things like the audit logs, we need to create it upfront before eks gets a chance so we can reference it.

⚠️ This will NOT apply cleanly, we will need to hijack pipeline containers for each cluster and manually run:

```
terraform import aws_cloudwatch_log_group.eks /aws/eks/${CLUSTER_NAME}/cluster
```

after this is merged and the manual import is applied we will need to revert the TMP commit