### PR TITLE
Splunky audit logs (part two)

### DIFF
--- a/modules/gsp-cluster/splunk-system.tf
+++ b/modules/gsp-cluster/splunk-system.tf
@@ -13,7 +13,7 @@ module "k8s_lambda_splunk_forwarder" {
 module "eks_lambda_splunk_forwarder" {
   source                    = "../lambda_splunk_forwarder"
   enabled                   = "${var.splunk_enabled}"
-  name                      = "pods"
+  name                      = "eks"
   cloudwatch_log_group_arn  = "${module.k8s-cluster.eks-log-group-arn}"
   cloudwatch_log_group_name = "${module.k8s-cluster.eks-log-group-name}"
   cluster_name              = "${var.cluster_name}"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -23,6 +23,7 @@ resource "aws_eks_cluster" "eks-cluster" {
   depends_on = [
     "aws_iam_role_policy_attachment.eks-cluster-policy",
     "aws_iam_role_policy_attachment.eks-service-policy",
+    "aws_cloudwatch_log_group.eks",
   ]
 }
 


### PR DESCRIPTION
## What

In [part 1](https://github.com/alphagov/gsp-terraform-ignition/pull/173) we had to TMP drop a `depends_on` and do some manual `terraform import`ing

in part 2 we revert the TMP bit and rename the lambda for clarity
