### PR TITLE
stop leaking cluster-values in task output

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -52,7 +52,7 @@ generate_cluster_values: &generate_cluster_values
       mkdir -p cluster-values
       echo "fetching cluster-values file from cluster-state..."
       jq -r '.values' ./cluster-state/metadata > ./cluster-values/values.yaml
-      cat ./cluster-values/values.yaml
+      echo "OK!"
   inputs:
   - name: cluster-state
   outputs:


### PR DESCRIPTION
cluster-values sometimes has somewhat sensitive data in it, probably better to keep it out of any build logs.